### PR TITLE
CI: Add WinCE smoke test with Device Emulator under Wine

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,6 +224,54 @@ jobs:
       - name: Update Navit-Download-Center
         run: bash scripts/update_download_center.sh
 
+  smoke_test_wince:
+    runs-on: ubuntu-latest
+    needs: build_wince
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: WinCE Archive
+          path: navit-package
+
+      - name: Cache Device Emulator and ROM
+        id: cache-emu
+        uses: actions/cache@v4
+        with:
+          path: emulator
+          key: wince-emu-v1
+
+      - name: Download and extract Device Emulator + ROM
+        if: steps.cache-emu.outputs.cache-hit != 'true'
+        run: bash scripts/ci/wince-setup-emulator.sh emulator
+
+      - name: Install Wine and display tools
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo mkdir -pm755 /etc/apt/keyrings
+          sudo wget -O /etc/apt/keyrings/winehq-archive.key \
+            https://dl.winehq.org/wine-builds/winehq.key
+          sudo wget -NP /etc/apt/sources.list.d/ \
+            "https://dl.winehq.org/wine-builds/ubuntu/dists/$(lsb_release -cs)/winehq-$(lsb_release -cs).sources"
+          sudo apt-get update
+          sudo apt-get install -y --install-recommends winehq-stable || \
+            sudo apt-get install -y wine wine32 wine64
+          sudo apt-get install -y xvfb imagemagick xdotool
+
+      - name: Run WinCE smoke test
+        run: bash scripts/ci/wince-smoke-test.sh
+        env:
+          SMOKE_TIMEOUT: "120"
+
+      - name: Upload smoke test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: WinCE Smoke Test Results
+          path: smoke-results/
+          retention-days: 14
+
   build_tomtom_minimal:
     runs-on: ubuntu-latest
     needs: sanity_check
@@ -273,7 +321,7 @@ jobs:
             bash scripts/update_download_center.sh
   merge_trunk_in_master:
     runs-on: ubuntu-latest
-    needs: [build_android, build_fdroid, build_wince, build_tomtom_minimal, build_linux, build_tomtom_plugin, build_win32]
+    needs: [build_android, build_fdroid, build_wince, smoke_test_wince, build_tomtom_minimal, build_linux, build_tomtom_plugin, build_win32]
     if: github.ref == 'refs/heads/trunk'
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -272,6 +272,55 @@ jobs:
           path: smoke-results/
           retention-days: 14
 
+  smoke_test_wince_landscape:
+    runs-on: ubuntu-latest
+    needs: build_wince
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: WinCE Archive
+          path: navit-package
+
+      - name: Cache Device Emulator and ROM
+        id: cache-emu
+        uses: actions/cache@v4
+        with:
+          path: emulator
+          key: wince-emu-v2
+
+      - name: Download and extract Device Emulator + ROM
+        if: steps.cache-emu.outputs.cache-hit != 'true'
+        run: bash scripts/ci/wince-setup-emulator.sh emulator
+
+      - name: Install Wine and display tools
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo mkdir -pm755 /etc/apt/keyrings
+          sudo wget -O /etc/apt/keyrings/winehq-archive.key \
+            https://dl.winehq.org/wine-builds/winehq.key
+          sudo wget -NP /etc/apt/sources.list.d/ \
+            "https://dl.winehq.org/wine-builds/ubuntu/dists/$(lsb_release -cs)/winehq-$(lsb_release -cs).sources"
+          sudo apt-get update
+          sudo apt-get install -y --install-recommends winehq-stable || \
+            sudo apt-get install -y wine wine32 wine64
+          sudo apt-get install -y xvfb imagemagick xdotool
+
+      - name: Run WinCE smoke test (landscape)
+        run: bash scripts/ci/wince-smoke-test.sh
+        env:
+          SMOKE_TIMEOUT: "180"
+          ROTATE: "1"
+
+      - name: Upload smoke test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: WinCE Smoke Test Results (Landscape)
+          path: smoke-results/
+          retention-days: 14
+
   build_tomtom_minimal:
     runs-on: ubuntu-latest
     needs: sanity_check
@@ -321,7 +370,7 @@ jobs:
             bash scripts/update_download_center.sh
   merge_trunk_in_master:
     runs-on: ubuntu-latest
-    needs: [build_android, build_fdroid, build_wince, smoke_test_wince, build_tomtom_minimal, build_linux, build_tomtom_plugin, build_win32]
+    needs: [build_android, build_fdroid, build_wince, smoke_test_wince, smoke_test_wince_landscape, build_tomtom_minimal, build_linux, build_tomtom_plugin, build_win32]
     if: github.ref == 'refs/heads/trunk'
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -262,7 +262,7 @@ jobs:
       - name: Run WinCE smoke test
         run: bash scripts/ci/wince-smoke-test.sh
         env:
-          SMOKE_TIMEOUT: "120"
+          SMOKE_TIMEOUT: "180"
 
       - name: Upload smoke test results
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,7 +240,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: emulator
-          key: wince-emu-v1
+          key: wince-emu-v2
 
       - name: Download and extract Device Emulator + ROM
         if: steps.cache-emu.outputs.cache-hit != 'true'

--- a/scripts/ci/wince-setup-emulator.sh
+++ b/scripts/ci/wince-setup-emulator.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# Download and extract Microsoft Device Emulator 3.0 and WM 6.1 ROM images.
+# Designed to run on GitHub-hosted Ubuntu runners (no Wine needed for extraction).
+#
+# Output:
+#   emulator/DeviceEmulator.exe  — the emulator binary
+#   emulator/rom.bin             — the WM ROM image
+#
+# Usage: bash scripts/ci/wince-setup-emulator.sh [output_dir]
+
+set -euo pipefail
+
+OUT_DIR="${1:-emulator}"
+mkdir -p "$OUT_DIR"
+cd "$OUT_DIR"
+
+log() { echo "[emu-setup] $*"; }
+
+# --- Install extraction tools if missing ---
+install_tools() {
+    local need_install=false
+    for tool in 7z msiextract cabextract; do
+        if ! command -v "$tool" &>/dev/null; then
+            need_install=true
+            break
+        fi
+    done
+    if $need_install; then
+        log "Installing extraction tools..."
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq p7zip-full msitools cabextract
+    fi
+}
+
+# --- Download Device Emulator 3.0 (32-bit) ---
+download_device_emulator() {
+    if [ -f "vs_emulator.exe" ]; then
+        log "Device Emulator installer already present"
+        return
+    fi
+    log "Downloading Microsoft Device Emulator 3.0 (32-bit)..."
+    curl -fSL --retry 3 -o vs_emulator.exe \
+        "https://archive.org/download/microsoft_emulators/vs_emulator.exe"
+    log "Downloaded vs_emulator.exe ($(du -h vs_emulator.exe | cut -f1))"
+}
+
+# --- Extract Device Emulator ---
+extract_device_emulator() {
+    if [ -f "DeviceEmulator.exe" ]; then
+        log "DeviceEmulator.exe already extracted"
+        return
+    fi
+
+    log "Extracting Device Emulator..."
+    mkdir -p emu_tmp
+
+    # vs_emulator.exe is a self-extracting setup — try multiple extraction methods
+    # Method 1: 7z (handles most installer formats)
+    if 7z x vs_emulator.exe -oemu_tmp -y >/dev/null 2>&1; then
+        log "Extracted with 7z"
+    # Method 2: cabextract
+    elif cabextract -d emu_tmp vs_emulator.exe >/dev/null 2>&1; then
+        log "Extracted with cabextract"
+    else
+        log "ERROR: Could not extract vs_emulator.exe with 7z or cabextract"
+        log "Contents may require Wine-based installation"
+        return 1
+    fi
+
+    # Search for DeviceEmulator.exe in extracted files
+    local found
+    found="$(find emu_tmp -iname "DeviceEmulator.exe" -print -quit 2>/dev/null || true)"
+
+    if [ -n "$found" ]; then
+        cp "$found" DeviceEmulator.exe
+        log "Found DeviceEmulator.exe: $(du -h DeviceEmulator.exe | cut -f1)"
+    else
+        # The installer may contain MSI files that need further extraction
+        log "DeviceEmulator.exe not found directly, checking for nested MSI/CAB..."
+        local msi_file
+        msi_file="$(find emu_tmp -iname "*.msi" -print -quit 2>/dev/null || true)"
+        if [ -n "$msi_file" ]; then
+            log "Found nested MSI: $msi_file"
+            mkdir -p emu_msi_tmp
+            msiextract "$msi_file" -C emu_msi_tmp 2>/dev/null || \
+                7z x "$msi_file" -oemu_msi_tmp -y >/dev/null 2>&1 || true
+            found="$(find emu_msi_tmp -iname "DeviceEmulator.exe" -print -quit 2>/dev/null || true)"
+            if [ -n "$found" ]; then
+                cp "$found" DeviceEmulator.exe
+                log "Found DeviceEmulator.exe in nested MSI: $(du -h DeviceEmulator.exe | cut -f1)"
+            fi
+            rm -rf emu_msi_tmp
+        fi
+
+        # Check for CAB files
+        if [ ! -f "DeviceEmulator.exe" ]; then
+            for cab in $(find emu_tmp -iname "*.cab" 2>/dev/null); do
+                mkdir -p emu_cab_tmp
+                cabextract -d emu_cab_tmp "$cab" >/dev/null 2>&1 || true
+                found="$(find emu_cab_tmp -iname "DeviceEmulator.exe" -print -quit 2>/dev/null || true)"
+                if [ -n "$found" ]; then
+                    cp "$found" DeviceEmulator.exe
+                    log "Found DeviceEmulator.exe in CAB: $(du -h DeviceEmulator.exe | cut -f1)"
+                    rm -rf emu_cab_tmp
+                    break
+                fi
+                rm -rf emu_cab_tmp
+            done
+        fi
+    fi
+
+    rm -rf emu_tmp
+
+    if [ ! -f "DeviceEmulator.exe" ]; then
+        log "ERROR: Could not find DeviceEmulator.exe after extraction"
+        log "Falling back to Wine-based installation..."
+        extract_device_emulator_wine
+    fi
+}
+
+# --- Fallback: extract using Wine ---
+extract_device_emulator_wine() {
+    log "Attempting Wine-based extraction of Device Emulator..."
+    local wine_prefix="$PWD/wine_tmp"
+    export WINEPREFIX="$wine_prefix"
+    export WINEARCH=win32
+    export WINEDEBUG=-all
+
+    # Initialize Wine prefix
+    xvfb-run -a wineboot --init 2>/dev/null
+    wineserver --wait 2>/dev/null || true
+
+    # Run the installer silently
+    xvfb-run -a wine vs_emulator.exe /quiet /norestart 2>/dev/null || true
+    wineserver --wait 2>/dev/null || true
+
+    # Find the installed binary
+    local found
+    found="$(find "$wine_prefix" -iname "DeviceEmulator.exe" -print -quit 2>/dev/null || true)"
+    if [ -n "$found" ]; then
+        cp "$found" DeviceEmulator.exe
+        log "Found DeviceEmulator.exe via Wine install: $(du -h DeviceEmulator.exe | cut -f1)"
+        # Also grab any DLLs from the same directory
+        local emu_dir
+        emu_dir="$(dirname "$found")"
+        cp "$emu_dir"/*.dll . 2>/dev/null || true
+    else
+        log "FATAL: Could not extract DeviceEmulator.exe by any method"
+        rm -rf "$wine_prefix"
+        return 1
+    fi
+
+    rm -rf "$wine_prefix"
+    unset WINEPREFIX WINEARCH WINEDEBUG
+}
+
+# --- Download WM 6.1 ROM images ---
+download_wm_images() {
+    if [ -f "rom.bin" ]; then
+        log "ROM image already present"
+        return
+    fi
+
+    log "Downloading Windows Mobile 6.1.4 Emulator Images..."
+
+    # Try the WM 6.1.4 emulator images from Internet Archive
+    if [ ! -f "wm_images_raw" ]; then
+        # The archive.org item may be an MSI or an EXE installer
+        curl -fSL --retry 3 -o wm_images_raw \
+            "https://archive.org/download/WM614Emulator/Windows%20Mobile%206.1.4%20Emulator%20Images%20-%20ENU.msi" 2>/dev/null || \
+        curl -fSL --retry 3 -o wm_images_raw \
+            "https://archive.org/download/windows-mobile-emulation-images-archive.-7z/Windows%20Mobile%20Emulation%20Images%20Archive.7z" 2>/dev/null || {
+            log "ERROR: Could not download WM emulator images"
+            return 1
+        }
+    fi
+
+    log "Downloaded WM images ($(du -h wm_images_raw | cut -f1))"
+    extract_wm_images
+}
+
+# --- Extract WM ROM .bin ---
+extract_wm_images() {
+    log "Extracting WM ROM images..."
+    mkdir -p wm_tmp
+
+    local ext
+    ext="$(file wm_images_raw | head -1)"
+
+    # Try extraction methods based on file type
+    if echo "$ext" | grep -qi "msi\|composite"; then
+        msiextract wm_images_raw -C wm_tmp 2>/dev/null || \
+            7z x wm_images_raw -owm_tmp -y >/dev/null 2>&1 || true
+    elif echo "$ext" | grep -qi "7-zip\|7z"; then
+        7z x wm_images_raw -owm_tmp -y >/dev/null 2>&1 || true
+    else
+        # Try all methods
+        msiextract wm_images_raw -C wm_tmp 2>/dev/null || \
+            7z x wm_images_raw -owm_tmp -y >/dev/null 2>&1 || \
+            cabextract -d wm_tmp wm_images_raw >/dev/null 2>&1 || true
+    fi
+
+    # Find .bin ROM files (should be >10MB for a real ROM image)
+    local rom_file
+    rom_file="$(find wm_tmp -iname "*.bin" -size +10M -print -quit 2>/dev/null || true)"
+
+    if [ -z "$rom_file" ]; then
+        # May need to extract nested CABs
+        log "No large .bin found directly, checking nested archives..."
+        for nested in $(find wm_tmp -iname "*.cab" -o -iname "*.msi" 2>/dev/null); do
+            mkdir -p wm_nested_tmp
+            cabextract -d wm_nested_tmp "$nested" >/dev/null 2>&1 || \
+                msiextract "$nested" -C wm_nested_tmp 2>/dev/null || \
+                7z x "$nested" -owm_nested_tmp -y >/dev/null 2>&1 || true
+            rom_file="$(find wm_nested_tmp -iname "*.bin" -size +10M -print -quit 2>/dev/null || true)"
+            if [ -n "$rom_file" ]; then
+                break
+            fi
+            rm -rf wm_nested_tmp
+        done
+    fi
+
+    if [ -n "$rom_file" ]; then
+        cp "$rom_file" rom.bin
+        log "Found ROM image: rom.bin ($(du -h rom.bin | cut -f1))"
+        # Also grab skin files if present
+        local skin_dir
+        skin_dir="$(dirname "$rom_file")"
+        find "$(dirname "$skin_dir")" -iname "*skin*" -exec cp {} . \; 2>/dev/null || true
+        find "$(dirname "$skin_dir")" -iname "*.xml" -path "*skin*" -exec cp {} . \; 2>/dev/null || true
+    else
+        log "ERROR: No ROM .bin image found after extraction"
+        log "Files found:"
+        find wm_tmp -type f -exec ls -lh {} \; 2>/dev/null | head -20
+        rm -rf wm_tmp wm_nested_tmp
+        return 1
+    fi
+
+    rm -rf wm_tmp wm_nested_tmp
+}
+
+# --- Main ---
+install_tools
+download_device_emulator
+extract_device_emulator
+download_wm_images
+
+log ""
+log "=== Setup Complete ==="
+if [ -f "DeviceEmulator.exe" ] && [ -f "rom.bin" ]; then
+    log "DeviceEmulator.exe: $(du -h DeviceEmulator.exe | cut -f1)"
+    log "rom.bin: $(du -h rom.bin | cut -f1)"
+    log "Ready for smoke test"
+    exit 0
+else
+    log "INCOMPLETE — missing files:"
+    [ ! -f "DeviceEmulator.exe" ] && log "  - DeviceEmulator.exe"
+    [ ! -f "rom.bin" ] && log "  - rom.bin"
+    exit 1
+fi

--- a/scripts/ci/wince-setup-emulator.sh
+++ b/scripts/ci/wince-setup-emulator.sh
@@ -40,7 +40,7 @@ download_device_emulator() {
     fi
     log "Downloading Microsoft Device Emulator 3.0 (32-bit)..."
     curl -fSL --retry 3 -o vs_emulator.exe \
-        "https://archive.org/download/microsoft_emulators/vs_emulator.exe"
+        "https://archive.org/download/microsoft_emulators/Microsoft%20Device%20Emulator%203.0%2032-bit/Microsoft_Device_Emulator_V3.exe"
     log "Downloaded vs_emulator.exe ($(du -h vs_emulator.exe | cut -f1))"
 }
 
@@ -167,7 +167,7 @@ download_wm_images() {
     if [ ! -f "wm_images_raw" ]; then
         # The archive.org item may be an MSI or an EXE installer
         curl -fSL --retry 3 -o wm_images_raw \
-            "https://archive.org/download/WM614Emulator/Windows%20Mobile%206.1.4%20Emulator%20Images%20-%20ENU.msi" 2>/dev/null || \
+            "https://archive.org/download/WM614Emulator/Windows%20Mobile%206.1.4%20Professional%20Images%20%28USA%29.msi" 2>/dev/null || \
         curl -fSL --retry 3 -o wm_images_raw \
             "https://archive.org/download/windows-mobile-emulation-images-archive.-7z/Windows%20Mobile%20Emulation%20Images%20Archive.7z" 2>/dev/null || {
             log "ERROR: Could not download WM emulator images"

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -10,6 +10,8 @@
 #   EMU_DIR        - emulator directory (default: emulator)
 #   NAVIT_DIR      - navit package directory (default: navit-package)
 #   SMOKE_TIMEOUT  - total timeout in seconds (default: 180)
+#   ROTATE         - emulator rotation: 0=portrait (default), 1=landscape-right,
+#                    2=upside-down, 3=landscape-left
 
 set -euo pipefail
 
@@ -17,6 +19,7 @@ EMU_DIR="${EMU_DIR:-emulator}"
 NAVIT_DIR="${NAVIT_DIR:-navit-package}"
 RESULTS_DIR="smoke-results"
 SMOKE_TIMEOUT="${SMOKE_TIMEOUT:-180}"
+ROTATE="${ROTATE:-0}"
 
 export WINEPREFIX="$PWD/.wine-emu"
 export WINEARCH=win32
@@ -89,8 +92,14 @@ log "rom.bin: $(du -h "$EMU_DIR/rom.bin" | cut -f1)"
 log "Navit package: $(find "$NAVIT_DIR" -type f | wc -l) files"
 
 # --- Start Xvfb ---
-log "Starting Xvfb..."
-Xvfb :99 -screen 0 320x480x24 &
+log "Starting Xvfb (rotate=$ROTATE)..."
+if [ "$ROTATE" = "1" ] || [ "$ROTATE" = "3" ]; then
+    # Landscape: WM screen 320x240 + Wine chrome
+    Xvfb :99 -screen 0 480x360x24 &
+else
+    # Portrait: WM screen 240x320 + Wine chrome
+    Xvfb :99 -screen 0 320x480x24 &
+fi
 XVFB_PID=$!
 export DISPLAY=:99
 sleep 2
@@ -111,10 +120,13 @@ SHARE_WIN="$(winepath -w "$(realpath "$NAVIT_DIR")")"
 # --- Launch Device Emulator ---
 log "Launching Device Emulator..."
 
+EMU_ARGS=("$ROM_WIN" /memsize 128 /sharedfolder "$SHARE_WIN")
+if [ "$ROTATE" != "0" ]; then
+    EMU_ARGS+=(/rotate "$ROTATE")
+fi
+
 wine "$EMU_DIR/DeviceEmulator.exe" \
-    "$ROM_WIN" \
-    /memsize 128 \
-    /sharedfolder "$SHARE_WIN" \
+    "${EMU_ARGS[@]}" \
     > "$RESULTS_DIR/wine-output.log" 2>&1 &
 EMU_PID=$!
 log "Device Emulator PID: $EMU_PID"
@@ -148,11 +160,6 @@ if ! kill -0 "$EMU_PID" 2>/dev/null; then
 fi
 
 # --- Navigate the WM UI to launch Navit ---
-# WM 6.1 Professional screen layout (240x320):
-#   Title bar: y=0-20  ("Start" text at ~x=30, y=8)
-#   Today screen content: y=20-295
-#   Softkey bar: y=295-320 ("Calendar" left, "Contacts" right)
-#
 # Navigation plan:
 #   1. Tap Start (top bar)
 #   2. Tap Programs in the Start menu
@@ -170,100 +177,137 @@ if [ -n "$WIN_ID" ]; then
     sleep 0.5
 fi
 
-# Step 1: Tap "Start" in WM title bar
-log "Step 1: Tapping Start..."
-emu_click 30 8
-sleep 3
-capture_screenshot "02-start-tapped"
+if [ "$ROTATE" = "1" ] || [ "$ROTATE" = "3" ]; then
+    # --- LANDSCAPE MODE (320x240) ---
+    # WM screen is 320w x 240h. Title bar at top, softkeys at bottom.
+    # Start button at top-left. Coordinates are estimated for first run.
 
-# Step 2: Tap "Programs" in the Start menu
-# From screenshot analysis of the WM 6.1 Start menu layout:
-#   Today:            y~30
-#   Office Mobile:    y~50
-#   Calendar:         y~68
-#   Contacts:         y~86
-#   Internet Explorer:y~104
-#   Messaging:        y~122
-#   "Recent Programs":y~148
-#   Programs:         y~170
-#   Settings:         y~190
-#   Help:             y~208
-log "Step 2: Tapping Programs..."
-emu_click 50 170
-sleep 3
-capture_screenshot "03-programs-tapped"
+    # Step 1: Tap "Start"
+    log "Step 1: Tapping Start..."
+    emu_click 30 8
+    sleep 3
+    capture_screenshot "02-start-tapped"
 
-# Step 3: Double-tap File Explorer in the Programs grid
-# From screenshot analysis of the Programs screen:
-#   Grid layout (3 columns x 4 rows):
-#     Row 1 (icon y~65, label y~85): Games(x~40), ActiveSync(x~120), Calculator(x~190)
-#     Row 2 (icon y~140, label y~162): File Explorer(x~40), Getting Started(x~120), Internet Sharing(x~190)
-#     Row 3 (icon y~210): Messenger(x~40), Notes(x~120), Pictures & Videos(x~190)
-#     Row 4 (icon y~280): Search(x~40), SimTkUI(x~120), Task Manager(x~190)
-# Single tap selects, double-tap opens.
-log "Step 3: Double-tapping File Explorer icon..."
-emu_dblclick 40 145
-sleep 3
-capture_screenshot "04-after-file-explorer-dblclick"
+    # Step 2: Tap "Programs" — menu is taller than screen, Programs near bottom
+    # In landscape the start menu shows fewer items before scrolling.
+    # Items are same height (~18px) but menu may need scrolling.
+    log "Step 2: Tapping Programs..."
+    emu_click 50 170
+    sleep 3
+    capture_screenshot "03-programs-tapped"
 
-# Check if we got File Explorer or are still on Programs
-# If still on Programs, try clicking the File Explorer text label
-log "Step 3b: Trying File Explorer label area..."
-emu_dblclick 40 165
-sleep 3
-capture_screenshot "05-after-label-dblclick"
+    # Step 3: Double-tap File Explorer in Programs grid
+    # Landscape grid may have more columns or same layout shifted.
+    # File Explorer: Row 2, Col 1 — estimate same relative position.
+    log "Step 3: Double-tapping File Explorer icon..."
+    emu_dblclick 40 145
+    sleep 3
+    capture_screenshot "04-after-file-explorer-dblclick"
 
-# Step 4: Navigate up to root, then to Storage Card
-# File Explorer opened in "Templates" folder. Need to go up to My Device root.
-# Bottom softkey bar: "Up" at bottom-left ~WM(40, 307), "Menu" at bottom-right ~WM(200, 307)
-log "Step 4: Navigating up to root..."
+    log "Step 3b: Trying File Explorer label area..."
+    emu_dblclick 40 165
+    sleep 3
+    capture_screenshot "05-after-label-dblclick"
 
-# Tap "Up" to go from Templates -> My Documents
-emu_click 40 307
-sleep 2
-capture_screenshot "06a-up1"
+    # Step 4: Navigate up to root
+    # Softkey bar: "Up" at bottom-left ~WM(40, 227)
+    log "Step 4: Navigating up to root..."
+    emu_click 40 227
+    sleep 2
+    capture_screenshot "06a-up1"
 
-# Tap "Up" again to go from My Documents -> My Device (root)
-emu_click 40 307
-sleep 2
-capture_screenshot "06b-up2"
+    emu_click 40 227
+    sleep 2
+    capture_screenshot "06b-up2"
 
-# Now we should be at \My Device root.
-# From screenshot analysis of root listing (06c):
-#   List items are ~18px tall, starting at WM y≈57:
-#   Application D...  y≈57
-#   ConnMgr           y≈75
-#   Documents a...    y≈93
-#   MUSIC             y≈111
-#   My Documents      y≈129
-#   Program Files     y≈147
-#   Storage Card      y≈165
-#   Temp              y≈183
-#   Windows           y≈201
-log "Step 4b: Looking for Storage Card in root..."
-capture_screenshot "06c-root-view"
+    # Root listing — same item order, same ~18px row height
+    # In landscape the list area starts at ~y=37 (shorter title/address bar)
+    # Storage Card is 7th item: y ≈ 37 + 6*18 = 145
+    log "Step 4b: Looking for Storage Card in root..."
+    capture_screenshot "06c-root-view"
 
-# Single-click navigates into folders in File Explorer list view
-emu_click 120 165
-sleep 3
-capture_screenshot "06d-storage-card"
+    emu_click 160 145
+    sleep 3
+    capture_screenshot "06d-storage-card"
 
-# Step 5: Find and tap navit.exe in Storage Card
-# From screenshot analysis of Storage Card listing (06d):
-#   espeak-data/      y≈57  (folder)
-#   icons/            y≈75  (folder)
-#   locale/           y≈93  (folder)
-#   navit  7.93M      y≈111 (navit.exe)
-#   navit  30.7K      y≈129 (navit.xml - opens in IE!)
-#   navit  5.46M      y≈147
-#   navit_layout_*    y≈165+
-log "Step 5: Looking for navit.exe..."
-capture_screenshot "07-folder-contents"
+    # Step 5: navit.exe is 4th item: y ≈ 37 + 3*18 = 91
+    log "Step 5: Looking for navit.exe..."
+    capture_screenshot "07-folder-contents"
 
-# navit.exe (7.93M) is the 4th item (after 3 folders, no maps/ folder)
-emu_click 120 111
-sleep 3
-capture_screenshot "07a-click-navit-exe"
+    emu_click 160 91
+    sleep 3
+    capture_screenshot "07a-click-navit-exe"
+else
+    # --- PORTRAIT MODE (240x320) ---
+    # WM screen is 240w x 320h.
+
+    # Step 1: Tap "Start" in WM title bar
+    log "Step 1: Tapping Start..."
+    emu_click 30 8
+    sleep 3
+    capture_screenshot "02-start-tapped"
+
+    # Step 2: Tap "Programs" in the Start menu
+    # Start menu layout (verified from screenshots):
+    #   Today:            y~30    Programs:         y~170
+    #   Office Mobile:    y~50    Settings:         y~190
+    #   Calendar:         y~68    Help:             y~208
+    #   Contacts:         y~86
+    #   Internet Explorer:y~104
+    #   Messaging:        y~122
+    log "Step 2: Tapping Programs..."
+    emu_click 50 170
+    sleep 3
+    capture_screenshot "03-programs-tapped"
+
+    # Step 3: Double-tap File Explorer in the Programs grid
+    # Grid layout (3 columns x 4 rows, verified from screenshots):
+    #   Row 1 (y~65-85):  Games(x~40), ActiveSync(x~120), Calculator(x~190)
+    #   Row 2 (y~140-162): File Explorer(x~40), Getting Started(x~120), Internet Sharing(x~190)
+    log "Step 3: Double-tapping File Explorer icon..."
+    emu_dblclick 40 145
+    sleep 3
+    capture_screenshot "04-after-file-explorer-dblclick"
+
+    log "Step 3b: Trying File Explorer label area..."
+    emu_dblclick 40 165
+    sleep 3
+    capture_screenshot "05-after-label-dblclick"
+
+    # Step 4: Navigate up to root, then to Storage Card
+    # Softkey bar: "Up" at bottom-left ~WM(40, 307)
+    log "Step 4: Navigating up to root..."
+
+    emu_click 40 307
+    sleep 2
+    capture_screenshot "06a-up1"
+
+    emu_click 40 307
+    sleep 2
+    capture_screenshot "06b-up2"
+
+    # Root listing (verified from screenshots):
+    #   Items ~18px tall, starting at WM y≈57:
+    #   Application D... y≈57, ConnMgr y≈75, Documents a... y≈93,
+    #   MUSIC y≈111, My Documents y≈129, Program Files y≈147,
+    #   Storage Card y≈165, Temp y≈183, Windows y≈201
+    log "Step 4b: Looking for Storage Card in root..."
+    capture_screenshot "06c-root-view"
+
+    emu_click 120 165
+    sleep 3
+    capture_screenshot "06d-storage-card"
+
+    # Step 5: navit.exe in Storage Card (verified from screenshots):
+    #   espeak-data/ y≈57, icons/ y≈75, locale/ y≈93,
+    #   navit.exe(7.93M) y≈111, navit.xml(30.7K) y≈129
+    log "Step 5: Looking for navit.exe..."
+    capture_screenshot "07-folder-contents"
+
+    emu_click 120 111
+    sleep 3
+    capture_screenshot "07a-click-navit-exe"
+fi
 
 # Give Navit time to start and render
 log "Waiting 15s for Navit to initialize..."

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -186,83 +186,75 @@ emu_click 50 170
 sleep 3
 capture_screenshot "03-programs-tapped"
 
-# Step 3: In Programs view, find and tap File Explorer
-# Programs view shows icons in a grid. File Explorer is typically present.
-# The grid starts around y=35, icons are ~70px apart in rows
-# First try common positions in the Programs grid
-log "Step 3: Looking for File Explorer in Programs grid..."
-capture_screenshot "03b-programs-view"
+# Step 3: Tap File Explorer in the Programs grid
+# From screenshot analysis of the Programs screen:
+#   Grid layout (3 columns x 4 rows visible):
+#     Row 1 (y~90):  Games(x~40), ActiveSync(x~120), Calculator(x~190)
+#     Row 2 (y~160): File Explorer(x~40), Getting Started(x~120), Internet Sharing(x~190)
+#     Row 3 (y~230): Messenger(x~40), Notes(x~120), Pictures & Videos(x~190)
+#     Row 4 (y~300): Search(x~40), SimTkUI(x~120), Task Manager(x~190)
+log "Step 3: Tapping File Explorer..."
+emu_click 40 160
+sleep 3
+capture_screenshot "04-file-explorer"
 
-# Programs grid layout is typically 3 columns x N rows
-# Icons at approximately: col1=40, col2=120, col3=200, rows at y=50,110,170,230
-# File Explorer is usually in the first page. Try several positions.
-# We'll click each and check the result.
-emu_click 40 50
-sleep 2
-capture_screenshot "04a-programs-click1"
+# Step 4: In File Explorer, navigate to Storage Card
+# File Explorer shows the \My Device root with items like:
+#   My Documents, Program Files, Storage Card, Temp, Windows, etc.
+# Items are in a list view. "Storage Card" should be visible.
+# List items start around y=35 with ~20px spacing.
+log "Step 4: Looking for Storage Card in File Explorer..."
+capture_screenshot "05-file-explorer-view"
 
-# Check if we opened File Explorer or something else
-# If it's not File Explorer, go back and try next icon
-emu_click 120 50
-sleep 2
-capture_screenshot "04b-programs-click2"
-
-emu_click 200 50
-sleep 2
-capture_screenshot "04c-programs-click3"
-
-emu_click 40 110
-sleep 2
-capture_screenshot "04d-programs-click4"
-
-emu_click 120 110
-sleep 2
-capture_screenshot "04e-programs-click5"
-
-emu_click 200 110
-sleep 2
-capture_screenshot "04f-programs-click6"
-
-# Take a state screenshot
-capture_screenshot "05-after-grid-clicks"
-
-# If we've reached File Explorer, we should see a list of folders/files.
-# Look for "Storage Card" and tap it.
-# In File Explorer list view, items start around y=40 with ~20px spacing
-log "Step 4: Looking for Storage Card..."
-sleep 2
-
-# Try tapping items in the file list
-emu_click 120 40
-sleep 2
-capture_screenshot "06a-list-item1"
-
-emu_click 120 60
-sleep 2
-capture_screenshot "06b-list-item2"
-
+# Scroll down if needed and try tapping "Storage Card"
+# It's typically several items down in the list
+# Try tapping items from top to bottom until we find it
 emu_click 120 80
 sleep 2
-capture_screenshot "06c-list-item3"
+capture_screenshot "06a-fe-item1"
 
-# Step 5: If we're in a folder, look for navit.exe
+emu_click 120 100
+sleep 2
+capture_screenshot "06b-fe-item2"
+
+emu_click 120 120
+sleep 2
+capture_screenshot "06c-fe-item3"
+
+emu_click 120 140
+sleep 2
+capture_screenshot "06d-fe-item4"
+
+emu_click 120 160
+sleep 2
+capture_screenshot "06e-fe-item5"
+
+# Step 5: In Storage Card folder, find and tap navit.exe
 log "Step 5: Looking for navit.exe..."
-emu_click 120 40
-sleep 2
-capture_screenshot "07a-navit-try1"
+capture_screenshot "07-storage-card-contents"
 
+# navit.exe should be one of the items in the folder
+# The build produces: navit.exe, navit.xml, icons/, locale/, espeak-data/, maps/
 emu_click 120 60
 sleep 2
-capture_screenshot "07b-navit-try2"
+capture_screenshot "08a-item1"
 
 emu_click 120 80
 sleep 2
-capture_screenshot "07c-navit-try3"
+capture_screenshot "08b-item2"
+
+emu_click 120 100
+sleep 2
+capture_screenshot "08c-item3"
+
+emu_click 120 120
+sleep 2
+capture_screenshot "08d-item4"
 
 # Give Navit time to start and render
 log "Waiting 15s for Navit to initialize..."
 sleep 15
-capture_screenshot "08-navit-running"
+capture_screenshot "09-navit-running"
 
 # --- Monitor for remaining time ---
 REMAINING=$((SMOKE_TIMEOUT - (SECONDS - START)))

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -62,13 +62,13 @@ log "Navit package: $(find "$NAVIT_DIR" -type f | wc -l) files"
 
 # --- Auto-start setup ---
 # Place autorun.exe in the ARM processor-specific subfolder (2577 = ARMV4I).
-# WinCE shell calls SHGetAutoRunPath() when a storage card is inserted and
+# WinCE shell calls SHGetAutoRunPath() when a storage card is INSERTED and
 # runs \Storage Card\<procID>\autorun.exe automatically.
-# We boot WITHOUT /sharedfolder and hot-plug it later via the Device Emulator's
-# File > Configure dialog so the shell sees a genuine card-insertion event.
+# We also place a copy at the root for ROMs that check there instead.
 mkdir -p "$NAVIT_DIR/2577"
 cp "$NAVIT_DIR/navit.exe" "$NAVIT_DIR/2577/autorun.exe"
-log "Created 2577/autorun.exe for SD card autorun"
+cp "$NAVIT_DIR/navit.exe" "$NAVIT_DIR/autorun.exe"
+log "Created autorun.exe at root and 2577/ for SD card autorun"
 
 # --- Start Xvfb ---
 log "Starting Xvfb (rotate=$ROTATE)..."
@@ -95,12 +95,12 @@ ROM_WIN="$(winepath -w "$(realpath "$EMU_DIR/rom.bin")")"
 SHARE_WIN="$(winepath -w "$(realpath "$NAVIT_DIR")")"
 
 # --- Launch Device Emulator ---
-# Boot WITH /sharedfolder so the Storage Card is available.
-# After the shell boots, we soft-reset via File > Reset > Soft to trigger
-# the autorun.exe mechanism on the second boot cycle.
-log "Launching Device Emulator..."
+# Boot WITHOUT /sharedfolder so we can hot-plug it later.
+# Hot-plugging triggers a genuine storage card insertion event in WinCE,
+# which causes the shell to detect and run autorun.exe.
+log "Launching Device Emulator (without shared folder)..."
 
-EMU_ARGS=("$ROM_WIN" /memsize 128 /sharedfolder "$SHARE_WIN")
+EMU_ARGS=("$ROM_WIN" /memsize 128)
 if [ "$ROTATE" = "1" ] || [ "$ROTATE" = "3" ]; then
     EMU_ARGS+=(/video 320x240x16)
 fi
@@ -139,15 +139,14 @@ if ! kill -0 "$EMU_PID" 2>/dev/null; then
     exit 1
 fi
 
-# --- Soft-reset to trigger autorun.exe ---
-# The Storage Card (shared folder) is present from boot, but the WinCE shell
-# may not trigger SHGetAutoRunPath() for a card that was already mounted.
-# A soft reset re-initializes the shell while keeping the Storage Card mounted,
-# which should trigger autorun detection on the second boot.
-log "Performing soft reset via File > Reset > Soft..."
+# --- Hot-plug storage card via File > Configure ---
+# Open the Device Emulator's Configure dialog and set the shared folder.
+# This triggers a genuine storage card insertion event in WinCE,
+# which causes the shell to execute autorun.exe → launches Navit.
+log "Hot-plugging storage card via File > Configure..."
 EMU_WID="$(xdotool search --name 'Device Emulator' 2>/dev/null | head -1 || true)"
 if [ -z "$EMU_WID" ]; then
-    log "WARNING: Could not find Device Emulator window for soft reset"
+    log "WARNING: Could not find Device Emulator window for hot-plug"
 else
     xdotool windowfocus "$EMU_WID" 2>/dev/null || true
     sleep 0.5
@@ -163,64 +162,106 @@ else
     sleep 1
     import -window root "$RESULTS_DIR/02-file-menu-$(date '+%H%M%S').png" 2>/dev/null || true
 
-    # Click "Reset >" submenu (3rd item in File dropdown)
-    #   Save State and Exit  (~16px)
-    #   Clear Saved State    (~16px)
-    #   Reset >              (~16px)  <-- target
-    MENU_X=$((X + 30))
-    MENU_Y=$((Y + 19 + 16*2 + 8))
-    log "Clicking Reset at absolute ($MENU_X, $MENU_Y)"
-    xdotool mousemove "$MENU_X" "$MENU_Y"
+    # Click "Configure..." (4th item in File dropdown)
+    #   Save State and Exit  (~18px)
+    #   Clear Saved State    (~18px)
+    #   Reset >              (~18px)
+    #   Configure...         (~18px)  <-- target
+    #   Exit
+    CONF_X=$((X + 50))
+    CONF_Y=$((Y + 19 + 18*3 + 9))
+    log "Clicking Configure at absolute ($CONF_X, $CONF_Y)"
+    xdotool mousemove "$CONF_X" "$CONF_Y"
     sleep 0.5
-    import -window root "$RESULTS_DIR/03-reset-hover-$(date '+%H%M%S').png" 2>/dev/null || true
-
-    # The submenu appears to the right of "Reset" with "Soft" as the first item.
-    # From screenshots: the submenu "Soft" is at roughly window-relative (155, 60).
-    # Move slowly rightward to keep the submenu open, then click "Soft".
-    xdotool mousemove --window "$EMU_WID" 100 60
-    sleep 0.3
-    xdotool mousemove --window "$EMU_WID" 140 60
-    sleep 0.3
-    xdotool mousemove --window "$EMU_WID" 165 60
-    sleep 0.3
-    import -window root "$RESULTS_DIR/04-submenu-hover-$(date '+%H%M%S').png" 2>/dev/null || true
+    import -window root "$RESULTS_DIR/03-configure-hover-$(date '+%H%M%S').png" 2>/dev/null || true
     xdotool click 1
     sleep 2
-    import -window root "$RESULTS_DIR/05-after-soft-click-$(date '+%H%M%S').png" 2>/dev/null || true
+    import -window root "$RESULTS_DIR/04-configure-dialog-$(date '+%H%M%S').png" 2>/dev/null || true
 
-    # A confirmation dialog appears: "Are you sure you want to reset the guest OS?"
-    # with Yes and No buttons. Click "Yes" with mouse coordinates.
-    # From screenshots: Yes button is at approximately (140, 305) in root window.
-    # The dialog is rendered inside the emulator window area.
-    sleep 1
-    import -window root "$RESULTS_DIR/06-confirm-dialog-$(date '+%H%M%S').png" 2>/dev/null || true
+    # The Configure dialog should now be open.
+    # We need to find and fill the "Shared Folder" field.
+    # Look for the Configure dialog window.
+    CONF_WID="$(xdotool search --name 'Emulator Properties' 2>/dev/null | head -1 || true)"
+    if [ -z "$CONF_WID" ]; then
+        CONF_WID="$(xdotool search --name 'Configure' 2>/dev/null | head -1 || true)"
+    fi
+    if [ -z "$CONF_WID" ]; then
+        CONF_WID="$(xdotool getactivewindow 2>/dev/null || true)"
+    fi
+    log "Configure dialog window: ${CONF_WID:-not found}"
 
-    # Click "Yes" button — it's at roughly window-relative (75, 275) based on
-    # the dialog being centered in the 240-wide emulator window
-    YES_X=$((X + 75))
-    YES_Y=$((Y + 275))
-    log "Clicking Yes at absolute ($YES_X, $YES_Y)"
-    xdotool mousemove "$YES_X" "$YES_Y"
-    sleep 0.3
-    xdotool click 1
-    sleep 1
-    import -window root "$RESULTS_DIR/07-after-confirm-$(date '+%H%M%S').png" 2>/dev/null || true
-    log "Soft reset confirmed"
+    if [ -n "$CONF_WID" ]; then
+        # Take a screenshot of the dialog window itself
+        import -window "$CONF_WID" "$RESULTS_DIR/05-configure-window-$(date '+%H%M%S').png" 2>/dev/null || true
 
-    # Wait for the emulator to reboot
-    sleep 5
-    EMU_WID2="$(xdotool search --name 'Device Emulator' 2>/dev/null | head -1 || true)"
-    if [ -n "$EMU_WID2" ]; then
-        log "Emulator window after reset: $EMU_WID2"
+        # Try to find the shared folder field.
+        # In the Device Emulator Properties dialog, there's typically a
+        # "Shared Folder" text field. Try using Tab to navigate to it.
+        # The dialog may have multiple tabs and fields.
+        # Strategy: use xdotool to type the shared folder path into the
+        # field. We'll try Alt+keyboard shortcuts first.
+
+        # First, let's see if there's a "General" or "Peripherals" tab
+        # with the shared folder. Take a screenshot of the dialog first.
+        xdotool windowfocus "$CONF_WID" 2>/dev/null || true
+        sleep 0.5
+
+        # Try clicking on "General" tab if it exists (usually first tab, top-left)
+        # Tab headers are typically at the top of the dialog
+        # Try clicking at various positions to find the shared folder field
+
+        # Get configure dialog geometry
+        eval "$(xdotool getwindowgeometry --shell "$CONF_WID" 2>/dev/null)" || {
+            log "Could not get Configure dialog geometry"
+        }
+        log "Configure dialog at X=$X Y=$Y W=${WIDTH:-?} H=${HEIGHT:-?}"
+
+        # The shared folder field is likely a text input near the bottom of
+        # the General tab. Try clearing any existing value and typing our path.
+        # Use Ctrl+A to select all text in a field, then type the new path.
+
+        # Navigate through the dialog controls with Tab
+        # Try tabbing through and typing at each position,
+        # taking screenshots to see where we are
+        for tab_count in 1 2 3 4 5 6 7 8; do
+            xdotool key Tab
+            sleep 0.2
+        done
+        import -window root "$RESULTS_DIR/06-after-tabs-$(date '+%H%M%S').png" 2>/dev/null || true
+
+        # Try typing the shared folder path
+        # First select all text in the current field
+        xdotool key ctrl+a
+        sleep 0.2
+        xdotool type --clearmodifiers "$SHARE_WIN"
+        sleep 0.5
+        import -window root "$RESULTS_DIR/07-after-type-$(date '+%H%M%S').png" 2>/dev/null || true
+
+        # Click OK to apply (typically bottom-right of dialog)
+        # OK button is usually at the bottom of the dialog
+        if [ -n "${WIDTH:-}" ] && [ -n "${HEIGHT:-}" ]; then
+            OK_X=$((X + WIDTH - 170))
+            OK_Y=$((Y + HEIGHT - 15))
+            log "Clicking OK at absolute ($OK_X, $OK_Y)"
+            xdotool mousemove "$OK_X" "$OK_Y"
+            sleep 0.3
+            xdotool click 1
+        else
+            # Fallback: press Enter for OK
+            xdotool key Return
+        fi
+        sleep 2
+        import -window root "$RESULTS_DIR/08-after-ok-$(date '+%H%M%S').png" 2>/dev/null || true
+        log "Configure dialog closed"
     else
-        log "WARNING: Emulator window not found after reset"
+        log "WARNING: Could not find Configure dialog window"
     fi
 fi
 
-# --- Wait for second boot + autorun ---
-log "Waiting 30s for WinCE to reboot and autorun.exe to launch Navit..."
+# --- Wait for Navit to launch via autorun ---
+log "Waiting 30s for autorun.exe to detect storage card and launch Navit..."
 sleep 30
-capture_screenshot "08-post-reset"
+capture_screenshot "09-post-hotplug"
 
 # --- Monitor for remaining time ---
 REMAINING=$((SMOKE_TIMEOUT - (SECONDS - START)))

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -165,12 +165,16 @@ else
     import -window root "$RESULTS_DIR/02-file-menu-$(date '+%H%M%S').png" 2>/dev/null || true
     log "Screenshot: 02-file-menu (root)"
 
-    # "Configure..." should be in the dropdown menu (a separate popup window).
-    # The dropdown appears below the menu bar at absolute screen coordinates.
-    # Menu items are ~20px tall. Configure is the 1st item under File.
-    # Calculate absolute position: window Y + menu bar height (~19px) + item offset
-    MENU_X=$((X + 15))
-    MENU_Y=$((Y + 28))
+    # "Configure..." is the 4th item in the File dropdown menu:
+    #   Save State and Exit  (~16px)
+    #   Clear Saved State    (~16px)
+    #   Reset >              (~16px)
+    #   Configure...         (~16px)  <-- target
+    #   Exit                 (~16px)
+    # The dropdown appears below the menu bar (19px tall).
+    # Each item is ~16px. Configure starts at offset ~67px from window top.
+    MENU_X=$((X + 30))
+    MENU_Y=$((Y + 19 + 16*3 + 8))
     log "Clicking Configure at absolute ($MENU_X, $MENU_Y)"
     xdotool mousemove "$MENU_X" "$MENU_Y"
     sleep 0.3

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -222,49 +222,41 @@ sleep 2
 capture_screenshot "06b-up2"
 
 # Now we should be at \My Device root.
-# Contents typically: My Documents, Program Files, Storage Card, Temp, Windows
-# Storage Card is the shared folder. Look for it in the list.
-# File Explorer list items: ~20px tall, starting around y=40
+# From screenshot analysis of root listing (06c):
+#   List items are ~18px tall, starting at WM y≈57:
+#   Application D...  y≈57
+#   ConnMgr           y≈75
+#   Documents a...    y≈93
+#   MUSIC             y≈111
+#   My Documents      y≈129
+#   Program Files     y≈147
+#   Storage Card      y≈165
+#   Temp              y≈183
+#   Windows           y≈201
 log "Step 4b: Looking for Storage Card in root..."
 capture_screenshot "06c-root-view"
 
-# Tap on items - Storage Card should be 3rd or 4th item
-# Items: My Documents(~y=40), Program Files(~y=60), Storage Card(~y=80)
-emu_click 120 80
-sleep 2
-capture_screenshot "06d-item-storage-card"
-
-# If that was the wrong item, try the next ones
-emu_click 120 100
-sleep 2
-capture_screenshot "06e-item4"
-
-emu_click 120 120
-sleep 2
-capture_screenshot "06f-item5"
+# Single-click navigates into folders in File Explorer list view
+emu_click 120 165
+sleep 3
+capture_screenshot "06d-storage-card"
 
 # Step 5: Find and tap navit.exe in Storage Card
-# The shared folder contains: espeak-data/, icons/, locale/, maps/,
-# navit.exe, navit.xml, navit_layout_*.xml
-# Folders come first alphabetically, then files:
-#   espeak-data/ (~y=40), icons/ (~y=60), locale/ (~y=80), maps/ (~y=100),
-#   navit.exe (~y=120), navit.xml (~y=140), navit_layout_*.xml (~y=160+)
+# The shared folder contains (folders first, then files alphabetically):
+#   espeak-data/   y≈57
+#   icons/         y≈75
+#   locale/        y≈93
+#   maps/          y≈111
+#   navit.exe      y≈129
+#   navit.xml      y≈147
+#   navit_layout_* y≈165+
 log "Step 5: Looking for navit.exe..."
 capture_screenshot "07-folder-contents"
 
-# navit.exe should be around the 5th item (after 4 folders)
-emu_click 120 120
-sleep 2
+# navit.exe should be the 5th item (after 4 folders)
+emu_click 120 129
+sleep 3
 capture_screenshot "07a-click-navit-exe"
-
-# Try adjacent positions in case the list ordering is different
-emu_click 120 100
-sleep 2
-capture_screenshot "07b-click-alt1"
-
-emu_click 120 140
-sleep 2
-capture_screenshot "07c-click-alt2"
 
 # Give Navit time to start and render
 log "Waiting 15s for Navit to initialize..."

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -94,12 +94,13 @@ log "Wine initialized"
 ROM_WIN="$(winepath -w "$(realpath "$EMU_DIR/rom.bin")")"
 SHARE_WIN="$(winepath -w "$(realpath "$NAVIT_DIR")")"
 
-# --- Launch Device Emulator (without shared folder) ---
-# Boot without /sharedfolder so we can hot-plug it later via the Configure
-# dialog, triggering a genuine SD card insertion event for autorun.exe.
-log "Launching Device Emulator (no shared folder)..."
+# --- Launch Device Emulator ---
+# Boot WITH /sharedfolder so the Storage Card is available.
+# After the shell boots, we soft-reset via File > Reset > Soft to trigger
+# the autorun.exe mechanism on the second boot cycle.
+log "Launching Device Emulator..."
 
-EMU_ARGS=("$ROM_WIN" /memsize 128)
+EMU_ARGS=("$ROM_WIN" /memsize 128 /sharedfolder "$SHARE_WIN")
 if [ "$ROTATE" = "1" ] || [ "$ROTATE" = "3" ]; then
     EMU_ARGS+=(/video 320x240x16)
 fi
@@ -138,97 +139,57 @@ if ! kill -0 "$EMU_PID" 2>/dev/null; then
     exit 1
 fi
 
-# --- Hot-plug shared folder via File > Configure dialog ---
-# This simulates inserting an SD card after boot, which triggers
-# SHGetAutoRunPath() -> \Storage Card\2577\autorun.exe -> navit.exe
-log "Hot-plugging shared folder via File > Configure..."
+# --- Soft-reset to trigger autorun.exe ---
+# The Storage Card (shared folder) is present from boot, but the WinCE shell
+# may not trigger SHGetAutoRunPath() for a card that was already mounted.
+# A soft reset re-initializes the shell while keeping the Storage Card mounted,
+# which should trigger autorun detection on the second boot.
+log "Performing soft reset via File > Reset > Soft..."
 EMU_WID="$(xdotool search --name 'Device Emulator' 2>/dev/null | head -1 || true)"
 if [ -z "$EMU_WID" ]; then
-    log "WARNING: Could not find Device Emulator window for hot-plug"
+    log "WARNING: Could not find Device Emulator window for soft reset"
 else
-    # Click "File" in the host menu bar using window-relative coordinates.
-    # The menu bar is rendered by Wine at the top of the window.
-    # "File" text is at approximately x=15, y=8 in the window.
     xdotool windowfocus "$EMU_WID" 2>/dev/null || true
     sleep 0.5
 
-    # Get window position for absolute coordinate calculation
+    # Get window geometry for menu coordinate calculation
     eval "$(xdotool getwindowgeometry --shell "$EMU_WID" 2>/dev/null)" || true
     log "Emulator window at X=$X Y=$Y W=${WIDTH:-?} H=${HEIGHT:-?}"
 
-    # Click on "File" menu text in the menu bar
+    # Click "File" in the host menu bar
     xdotool mousemove --window "$EMU_WID" 15 8
     sleep 0.3
     xdotool click --window "$EMU_WID" 1
     sleep 1
-    # Take a full-screen screenshot to see the menu dropdown
     import -window root "$RESULTS_DIR/02-file-menu-$(date '+%H%M%S').png" 2>/dev/null || true
-    log "Screenshot: 02-file-menu (root)"
 
-    # "Configure..." is the 4th item in the File dropdown menu:
+    # Click "Reset >" submenu (3rd item in File dropdown)
     #   Save State and Exit  (~16px)
     #   Clear Saved State    (~16px)
-    #   Reset >              (~16px)
-    #   Configure...         (~16px)  <-- target
-    #   Exit                 (~16px)
-    # The dropdown appears below the menu bar (19px tall).
-    # Each item is ~16px. Configure starts at offset ~67px from window top.
+    #   Reset >              (~16px)  <-- target
     MENU_X=$((X + 30))
-    MENU_Y=$((Y + 19 + 16*3 + 8))
-    log "Clicking Configure at absolute ($MENU_X, $MENU_Y)"
+    MENU_Y=$((Y + 19 + 16*2 + 8))
+    log "Clicking Reset at absolute ($MENU_X, $MENU_Y)"
     xdotool mousemove "$MENU_X" "$MENU_Y"
+    sleep 0.5
+    import -window root "$RESULTS_DIR/03-reset-hover-$(date '+%H%M%S').png" 2>/dev/null || true
+
+    # The submenu should appear to the right. Click "Soft" (first item).
+    SUBMENU_X=$((MENU_X + 100))
+    SUBMENU_Y=$((MENU_Y))
+    log "Clicking Soft Reset at absolute ($SUBMENU_X, $SUBMENU_Y)"
+    xdotool mousemove "$SUBMENU_X" "$SUBMENU_Y"
     sleep 0.3
     xdotool click 1
     sleep 2
-    import -window root "$RESULTS_DIR/03-after-menu-click-$(date '+%H%M%S').png" 2>/dev/null || true
-    log "Screenshot: 03-after-menu-click (root)"
-
-    # Search for any new dialog window that appeared
-    CFG_WID=""
-    for title in "Emulator Properties" "Configure" "General"; do
-        CFG_WID="$(xdotool search --name "$title" 2>/dev/null | head -1 || true)"
-        [ -n "$CFG_WID" ] && break
-    done
-
-    if [ -n "$CFG_WID" ]; then
-        log "Configure dialog found: $CFG_WID"
-        import -window root "$RESULTS_DIR/04-configure-dialog-$(date '+%H%M%S').png" 2>/dev/null || true
-
-        # Tab through to the Shared folder field, then type the path
-        xdotool windowfocus "$CFG_WID" 2>/dev/null || true
-        sleep 0.5
-        for i in $(seq 1 12); do
-            xdotool key --window "$CFG_WID" Tab
-            sleep 0.2
-        done
-        sleep 0.5
-        xdotool type --window "$CFG_WID" --delay 50 "$SHARE_WIN"
-        sleep 1
-        import -window root "$RESULTS_DIR/05-shared-folder-set-$(date '+%H%M%S').png" 2>/dev/null || true
-
-        # Press Enter to confirm (OK button)
-        xdotool key --window "$CFG_WID" Return
-        sleep 2
-        log "Shared folder set via Configure dialog"
-    else
-        log "WARNING: Configure dialog not found. Trying keyboard shortcut approach..."
-        import -window root "$RESULTS_DIR/04-no-dialog-$(date '+%H%M%S').png" 2>/dev/null || true
-
-        # Fallback: try sending Alt+F,C via X keyboard events to the root
-        xdotool key alt+f
-        sleep 1
-        xdotool key c
-        sleep 2
-        import -window root "$RESULTS_DIR/05-fallback-$(date '+%H%M%S').png" 2>/dev/null || true
-    fi
-    capture_screenshot "06-after-hotplug"
-    log "Shared folder hot-plug attempted: $SHARE_WIN"
+    import -window root "$RESULTS_DIR/04-after-reset-$(date '+%H%M%S').png" 2>/dev/null || true
+    log "Soft reset triggered"
 fi
 
-# --- Wait for autorun to trigger ---
-log "Waiting 15s for autorun.exe to launch Navit..."
-sleep 15
-capture_screenshot "07-navit-check"
+# --- Wait for second boot + autorun ---
+log "Waiting 30s for WinCE to reboot and autorun.exe to launch Navit..."
+sleep 30
+capture_screenshot "05-post-reset"
 
 # --- Monitor for remaining time ---
 REMAINING=$((SMOKE_TIMEOUT - (SECONDS - START)))

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -175,23 +175,20 @@ if [ -n "$WIN_ID" ]; then
 fi
 
 # Rotate screen if requested. Device Emulator doesn't support /rotate CLI flag.
-# Use the Wine menu bar: Flash > Rotate Right (each = 90 degrees clockwise).
-# Window-relative coords: menu bar at y≈12, "Flash" at x≈50.
+# Use the Wine menu bar: Flash > Rotate Right via keyboard navigation.
 if [ "$ROTATE" != "0" ]; then
     log "Rotating screen $ROTATE x 90 degrees via Flash menu..."
     for i in $(seq 1 "$ROTATE"); do
-        # Click "Flash" in the Wine menu bar (window-relative coords)
-        xdotool mousemove --window "$WIN_ID" 50 12
-        sleep 0.3
-        xdotool mousedown 1; sleep 0.1; xdotool mouseup 1
+        # Alt+L opens the "fLash" menu (Alt+F is File, Alt+H is Help)
+        xdotool key --window "$WIN_ID" alt+l 2>/dev/null || true
         sleep 1
         capture_screenshot "00-flash-menu-$i"
-        # Click "Rotate Right" in the dropdown menu
-        # Dropdown items appear below the menu bar, ~18px each
-        # Try first few positions to find Rotate Right
-        xdotool mousemove --window "$WIN_ID" 80 30
-        sleep 0.2
-        xdotool mousedown 1; sleep 0.1; xdotool mouseup 1
+        # Navigate dropdown with arrow keys and Enter
+        # Rotate Right should be one of the first items
+        xdotool key --window "$WIN_ID" Down 2>/dev/null || true
+        sleep 0.3
+        capture_screenshot "00-flash-item-$i"
+        xdotool key --window "$WIN_ID" Return 2>/dev/null || true
         sleep 2
         capture_screenshot "00-rotate-click-$i"
     done

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -189,16 +189,22 @@ else
     import -window root "$RESULTS_DIR/05-after-soft-click-$(date '+%H%M%S').png" 2>/dev/null || true
 
     # A confirmation dialog appears: "Are you sure you want to reset the guest OS?"
-    # with Yes and No buttons. Click "Yes" to confirm.
-    CONFIRM_WID="$(xdotool search --name 'Device Emulator' 2>/dev/null | tail -1 || true)"
-    log "Confirmation dialog search result: $CONFIRM_WID"
-
-    # The "Yes" button is on the left side of the dialog, roughly centered.
-    # From screenshot: dialog is centered in the window, Yes at ~(130, 275)
-    # relative to emulator window. Just press Enter since Yes appears focused.
-    xdotool key --window "$CONFIRM_WID" Return
+    # with Yes and No buttons. Click "Yes" with mouse coordinates.
+    # From screenshots: Yes button is at approximately (140, 305) in root window.
+    # The dialog is rendered inside the emulator window area.
     sleep 1
-    import -window root "$RESULTS_DIR/06-after-confirm-$(date '+%H%M%S').png" 2>/dev/null || true
+    import -window root "$RESULTS_DIR/06-confirm-dialog-$(date '+%H%M%S').png" 2>/dev/null || true
+
+    # Click "Yes" button — it's at roughly window-relative (75, 275) based on
+    # the dialog being centered in the 240-wide emulator window
+    YES_X=$((X + 75))
+    YES_Y=$((Y + 275))
+    log "Clicking Yes at absolute ($YES_X, $YES_Y)"
+    xdotool mousemove "$YES_X" "$YES_Y"
+    sleep 0.3
+    xdotool click 1
+    sleep 1
+    import -window root "$RESULTS_DIR/07-after-confirm-$(date '+%H%M%S').png" 2>/dev/null || true
     log "Soft reset confirmed"
 
     # Wait for the emulator to reboot
@@ -214,7 +220,7 @@ fi
 # --- Wait for second boot + autorun ---
 log "Waiting 30s for WinCE to reboot and autorun.exe to launch Navit..."
 sleep 30
-capture_screenshot "07-post-reset"
+capture_screenshot "08-post-reset"
 
 # --- Monitor for remaining time ---
 REMAINING=$((SMOKE_TIMEOUT - (SECONDS - START)))

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# WinCE Smoke Test: Boot Device Emulator under Wine+Xvfb, launch Navit, verify startup.
+# WinCE Smoke Test: Boot Device Emulator under Wine+Xvfb, auto-launch Navit, verify startup.
 #
 # Expects:
 #   emulator/DeviceEmulator.exe  — from wince-setup-emulator.sh
@@ -44,37 +44,6 @@ capture_screenshot() {
     fi
 }
 
-# Click inside the WM screen area of the emulator.
-# The emulator window starts at screen position (3, 29) with a 19px Wine menu bar.
-# The WM screen area starts at screen (3, 48) and is 240x320 pixels.
-# WM coordinates (0,0) = screen (3, 48).
-emu_click() {
-    local wmx="$1" wmy="$2"
-    local sx=$((3 + wmx))
-    local sy=$((48 + wmy))
-    log "Click WM($wmx,$wmy) -> screen($sx,$sy)"
-    xdotool mousemove "$sx" "$sy"
-    sleep 0.3
-    xdotool mousedown 1
-    sleep 0.1
-    xdotool mouseup 1
-    sleep 1
-}
-
-# Double-click inside the WM screen area
-emu_dblclick() {
-    local wmx="$1" wmy="$2"
-    local sx=$((3 + wmx))
-    local sy=$((48 + wmy))
-    log "DblClick WM($wmx,$wmy) -> screen($sx,$sy)"
-    xdotool mousemove "$sx" "$sy"
-    sleep 0.2
-    xdotool mousedown 1; sleep 0.05; xdotool mouseup 1
-    sleep 0.15
-    xdotool mousedown 1; sleep 0.05; xdotool mouseup 1
-    sleep 1
-}
-
 cleanup() {
     log "Cleaning up..."
     [ -n "${EMU_PID:-}" ] && kill "$EMU_PID" 2>/dev/null && sleep 1 && kill -9 "$EMU_PID" 2>/dev/null || true
@@ -91,13 +60,16 @@ log "DeviceEmulator.exe: $(du -h "$EMU_DIR/DeviceEmulator.exe" | cut -f1)"
 log "rom.bin: $(du -h "$EMU_DIR/rom.bin" | cut -f1)"
 log "Navit package: $(find "$NAVIT_DIR" -type f | wc -l) files"
 
+# --- Auto-start: copy navit.exe as autorun.exe on the Storage Card ---
+# WinCE auto-executes \Storage Card\autorun.exe when the card is detected.
+cp "$NAVIT_DIR/navit.exe" "$NAVIT_DIR/autorun.exe"
+log "Created autorun.exe ($(du -h "$NAVIT_DIR/autorun.exe" | cut -f1))"
+
 # --- Start Xvfb ---
 log "Starting Xvfb (rotate=$ROTATE)..."
 if [ "$ROTATE" = "1" ] || [ "$ROTATE" = "3" ]; then
-    # Landscape: WM screen 320x240 + Wine chrome
     Xvfb :99 -screen 0 480x360x24 &
 else
-    # Portrait: WM screen 240x320 + Wine chrome
     Xvfb :99 -screen 0 320x480x24 &
 fi
 XVFB_PID=$!
@@ -122,7 +94,6 @@ log "Launching Device Emulator..."
 
 EMU_ARGS=("$ROM_WIN" /memsize 128 /sharedfolder "$SHARE_WIN")
 if [ "$ROTATE" = "1" ] || [ "$ROTATE" = "3" ]; then
-    # Override video mode for landscape (320x240 instead of default 240x320)
     EMU_ARGS+=(/video 320x240x16)
 fi
 
@@ -150,9 +121,9 @@ for i in $(seq 1 30); do
     sleep 2
 done
 
-# --- Let WM finish booting ---
-log "Waiting 20s for WM to stabilize..."
-sleep 20
+# --- Let WM finish booting + autorun.exe to launch Navit ---
+log "Waiting 30s for WM to boot and autorun.exe to launch Navit..."
+sleep 30
 capture_screenshot "01-post-boot"
 
 if ! kill -0 "$EMU_PID" 2>/dev/null; then
@@ -160,165 +131,7 @@ if ! kill -0 "$EMU_PID" 2>/dev/null; then
     exit 1
 fi
 
-# --- Navigate the WM UI to launch Navit ---
-# Navigation plan:
-#   1. Tap Start (top bar)
-#   2. Tap Programs in the Start menu
-#   3. Tap File Explorer in the Programs list
-#   4. Navigate to Storage Card
-#   5. Tap navit.exe
-
-log "=== Launching Navit via UI navigation ==="
-
-# Focus the emulator window first
-WIN_ID="$(xdotool search --name 'Device Emulator' 2>/dev/null | head -1 || true)"
-if [ -n "$WIN_ID" ]; then
-    xdotool windowactivate "$WIN_ID" 2>/dev/null || true
-    xdotool windowfocus "$WIN_ID" 2>/dev/null || true
-    sleep 0.5
-fi
-
-if [ "$ROTATE" != "0" ]; then
-    capture_screenshot "00-after-rotate"
-fi
-
-if [ "$ROTATE" = "1" ] || [ "$ROTATE" = "3" ]; then
-    # --- LANDSCAPE MODE (320x240) ---
-    # WM screen is 320w x 240h. Title bar at top, softkeys at bottom.
-
-    # Step 1: Tap "Start"
-    log "Step 1: Tapping Start..."
-    emu_click 30 8
-    sleep 3
-    capture_screenshot "02-start-tapped"
-
-    # Step 2: Tap "Programs" (WM(50,170) verified working in landscape v6 run)
-    log "Step 2: Tapping Programs..."
-    emu_click 50 170
-    sleep 3
-    capture_screenshot "03-programs-tapped"
-
-    # Step 3: Double-tap File Explorer in Programs grid
-    # Landscape grid is 4 columns x 3 rows (verified from screenshot):
-    #   Row 1 (y~65): Games(x~40), ActiveSync(x~115), Calculator(x~195), File Explorer(x~270)
-    #   Row 2 (y~140): Getting Started(x~40), Internet Sharing(x~115), Messenger(x~195), Notes(x~270)
-    #   Row 3 (y~210): Pictures&(x~40), Search(x~115), SimTkUI(x~195), Task(x~270)
-    log "Step 3: Double-tapping File Explorer icon..."
-    emu_dblclick 270 65
-    sleep 3
-    capture_screenshot "04-after-file-explorer-dblclick"
-
-    log "Step 3b: Trying File Explorer label area..."
-    emu_dblclick 270 80
-    sleep 3
-    capture_screenshot "05-after-label-dblclick"
-
-    # Step 4: Navigate up to root
-    # Softkey bar at bottom of 240px screen: "Up" at ~WM(40, 227)
-    log "Step 4: Navigating up to root..."
-    emu_click 40 227
-    sleep 2
-    capture_screenshot "06a-up1"
-
-    emu_click 40 227
-    sleep 2
-    capture_screenshot "06b-up2"
-
-    # Root listing (verified from landscape screenshot):
-    #   Items ~18px tall, starting at y≈50:
-    #   Application Data y≈50, ConnMgr y≈68, Documents and Settings y≈86,
-    #   MUSIC y≈104, My Documents y≈122, Program Files y≈140,
-    #   Storage Card y≈158, Temp y≈176, Windows y≈194
-    log "Step 4b: Looking for Storage Card in root..."
-    capture_screenshot "06c-root-view"
-
-    emu_click 160 158
-    sleep 3
-    capture_screenshot "06d-storage-card"
-
-    # navit.exe is 4th item: y ≈ 50 + 3*18 = 104
-    log "Step 5: Looking for navit.exe..."
-    capture_screenshot "07-folder-contents"
-
-    emu_click 160 104
-    sleep 3
-    capture_screenshot "07a-click-navit-exe"
-else
-    # --- PORTRAIT MODE (240x320) ---
-    # WM screen is 240w x 320h.
-
-    # Step 1: Tap "Start" in WM title bar
-    log "Step 1: Tapping Start..."
-    emu_click 30 8
-    sleep 3
-    capture_screenshot "02-start-tapped"
-
-    # Step 2: Tap "Programs" in the Start menu
-    # Start menu layout (verified from screenshots):
-    #   Today:            y~30    Programs:         y~170
-    #   Office Mobile:    y~50    Settings:         y~190
-    #   Calendar:         y~68    Help:             y~208
-    #   Contacts:         y~86
-    #   Internet Explorer:y~104
-    #   Messaging:        y~122
-    log "Step 2: Tapping Programs..."
-    emu_click 50 170
-    sleep 3
-    capture_screenshot "03-programs-tapped"
-
-    # Step 3: Double-tap File Explorer in the Programs grid
-    # Grid layout (3 columns x 4 rows, verified from screenshots):
-    #   Row 1 (y~65-85):  Games(x~40), ActiveSync(x~120), Calculator(x~190)
-    #   Row 2 (y~140-162): File Explorer(x~40), Getting Started(x~120), Internet Sharing(x~190)
-    log "Step 3: Double-tapping File Explorer icon..."
-    emu_dblclick 40 145
-    sleep 3
-    capture_screenshot "04-after-file-explorer-dblclick"
-
-    log "Step 3b: Trying File Explorer label area..."
-    emu_dblclick 40 165
-    sleep 3
-    capture_screenshot "05-after-label-dblclick"
-
-    # Step 4: Navigate up to root, then to Storage Card
-    # Softkey bar: "Up" at bottom-left ~WM(40, 307)
-    log "Step 4: Navigating up to root..."
-
-    emu_click 40 307
-    sleep 2
-    capture_screenshot "06a-up1"
-
-    emu_click 40 307
-    sleep 2
-    capture_screenshot "06b-up2"
-
-    # Root listing (verified from screenshots):
-    #   Items ~18px tall, starting at WM y≈57:
-    #   Application D... y≈57, ConnMgr y≈75, Documents a... y≈93,
-    #   MUSIC y≈111, My Documents y≈129, Program Files y≈147,
-    #   Storage Card y≈165, Temp y≈183, Windows y≈201
-    log "Step 4b: Looking for Storage Card in root..."
-    capture_screenshot "06c-root-view"
-
-    emu_click 120 165
-    sleep 3
-    capture_screenshot "06d-storage-card"
-
-    # Step 5: navit.exe in Storage Card (verified from screenshots):
-    #   espeak-data/ y≈57, icons/ y≈75, locale/ y≈93,
-    #   navit.exe(7.93M) y≈111, navit.xml(30.7K) y≈129
-    log "Step 5: Looking for navit.exe..."
-    capture_screenshot "07-folder-contents"
-
-    emu_click 120 111
-    sleep 3
-    capture_screenshot "07a-click-navit-exe"
-fi
-
-# Give Navit time to start and render
-log "Waiting 15s for Navit to initialize..."
-sleep 15
-capture_screenshot "08-navit-result"
+capture_screenshot "02-navit-check"
 
 # --- Monitor for remaining time ---
 REMAINING=$((SMOKE_TIMEOUT - (SECONDS - START)))

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -50,17 +50,6 @@ emu_key() {
     sleep 0.3
 }
 
-# Tap a point on the WinCE guest screen (guest coords).
-# The WinCE display starts below the host menu bar (~19px).
-MENU_BAR_H=19
-tap_guest() {
-    local gx="$1" gy="$2" label="${3:-}"
-    [ -n "$label" ] && log "Tap ($gx,$gy) [${label}]"
-    xdotool mousemove --window "$EMU_WID" "$gx" "$((gy + MENU_BAR_H))"
-    sleep 0.3
-    xdotool click --window "$EMU_WID" 1
-}
-
 cleanup() {
     log "Cleaning up..."
     [ -n "${EMU_PID:-}" ] && kill "$EMU_PID" 2>/dev/null && sleep 1 && kill -9 "$EMU_PID" 2>/dev/null || true
@@ -148,19 +137,16 @@ fi
 # --- Launch Navit via WinCE File Explorer ---
 # Navigate: Start > Programs > File Explorer > [root] > Storage Card > navit.exe
 #
-# Confirmed from CI screenshots:
-#
-# Start menu items (Super key opens it):
-#   Today, Office Mobile, Calendar, Contacts, Internet Explorer, Messaging,
-#   [Recent Programs header], Programs, Settings, Help
-#
-# Programs grid (4 columns):
-#   Row 1: Games | ActiveSync | Calculator | File Explorer
-#
-# My Device root folders (F1 = Up from My Documents):
-#   Application Data, ConnMgr, Documents and Settings, MUSIC,
-#   My Documents, Program Files, Storage Card, Temp, Windows
-#   → Storage Card is the 7th item (6 Down from Application Data)
+# All navigation uses keyboard (Super, arrows, Enter, F1).
+# Confirmed from CI:
+#   - Super opens Start menu
+#   - In landscape: 6 Down reaches Programs (Today is pre-selected)
+#   - In portrait: may need 7 Down (if nothing is pre-selected)
+#   - Enter opens the selected item
+#   - Programs grid: 3 Right from Games reaches File Explorer
+#   - F1 in File Explorer = "Up" (goes from My Documents to My Device root)
+#   - My Device root has 9 folders; Storage Card is 7th (6 Down)
+
 log "Navigating WinCE GUI to launch navit.exe..."
 
 if [ -z "$EMU_WID" ]; then
@@ -169,89 +155,102 @@ else
     xdotool windowfocus "$EMU_WID" 2>/dev/null || true
     sleep 0.5
 
-    # Step 1: Open Start menu with Super key
-    log "Step 1: Opening Start menu..."
+    # Step 1: Open Start menu
+    log "Step 1: Opening Start menu (Super key)..."
     emu_key super
     sleep 1
     capture_screenshot "02-start-menu"
 
-    # Step 2: Tap "Programs" in the Start menu
-    # Use direct tap coordinates instead of arrow keys (more reliable).
-    # From CI screenshots:
-    #   Landscape (320x240): Programs at approx guest (70, 168)
-    #   Portrait (240x320): Programs at approx guest (70, 218)
-    log "Step 2: Tapping Programs..."
+    # Step 2: Navigate to Programs
+    # Landscape: Today is pre-selected → 6 Down reaches Programs
+    # Portrait: might not have pre-selection → 7 Down as fallback
+    # Use 7 Down for safety (if already on Programs, one extra Down goes to Settings,
+    # but we then press Up once to compensate).
+    # Actually: use different counts per orientation.
     if [ "$ROTATE" = "1" ] || [ "$ROTATE" = "3" ]; then
-        tap_guest 70 168 "Programs (landscape)"
+        log "Step 2: Navigating to Programs (landscape: 6x Down)..."
+        DOWN_COUNT=6
     else
-        tap_guest 70 218 "Programs (portrait)"
+        log "Step 2: Navigating to Programs (portrait: 7x Down)..."
+        DOWN_COUNT=7
     fi
-    sleep 2
-    capture_screenshot "03-programs-screen"
+    for i in $(seq 1 $DOWN_COUNT); do
+        emu_key Down
+    done
+    sleep 0.5
+    capture_screenshot "03-programs-highlighted"
 
-    # Step 3: Tap "File Explorer" in the Programs grid
-    # From CI screenshots: File Explorer is at row 1, col 4 (top-right area).
-    #   Landscape (320x240): File Explorer icon at approx guest (275, 55)
-    #   Portrait (240x320): File Explorer icon at approx guest (195, 55)
-    log "Step 3: Tapping File Explorer..."
-    if [ "$ROTATE" = "1" ] || [ "$ROTATE" = "3" ]; then
-        tap_guest 275 55 "File Explorer (landscape)"
-    else
-        tap_guest 195 55 "File Explorer (portrait)"
-    fi
+    log "Step 2b: Opening Programs (Enter)..."
+    emu_key Return
     sleep 2
-    capture_screenshot "04-file-explorer"
+    capture_screenshot "04-programs-screen"
 
-    # Step 4: Go up to My Device root with F1 (left softkey = "Up")
-    # File Explorer defaults to "My Documents".
-    # F1 = "Up" in File Explorer → goes to My Device root.
-    log "Step 4: Pressing F1 (Up) to reach My Device root..."
+    # Step 3: Navigate to File Explorer in Programs grid
+    # Grid: Games(col1) → ActiveSync(col2) → Calculator(col3) → File Explorer(col4)
+    # 3 Right presses from default selection (Games).
+    log "Step 3: Navigating to File Explorer (3x Right)..."
+    emu_key Right
+    emu_key Right
+    emu_key Right
+    sleep 0.5
+    capture_screenshot "05-file-explorer-highlighted"
+    emu_key Return
+    sleep 2
+    capture_screenshot "06-file-explorer-opened"
+
+    # Step 4: Navigate up from My Documents to My Device root
+    # F1 = left softkey = "Up" in File Explorer
+    log "Step 4: Going up to root (F1 = Up)..."
     emu_key F1
     sleep 1
-    capture_screenshot "05-my-device-root"
+    capture_screenshot "07-my-device-root"
 
     # Step 5: Navigate to Storage Card
-    # My Device root (from CI screenshot):
-    #   1. Application Data (selected by default)
+    # My Device root (confirmed from CI):
+    #   1. Application Data (selected)
     #   2. ConnMgr
     #   3. Documents and Settings
     #   4. MUSIC
     #   5. My Documents
     #   6. Program Files
-    #   7. Storage Card  ← target (6 Down presses)
+    #   7. Storage Card  ← target (6 Down)
     log "Step 5: Navigating to Storage Card (6x Down)..."
     for i in 1 2 3 4 5 6; do
         emu_key Down
     done
     sleep 0.5
-    capture_screenshot "06-storage-card-highlighted"
+    capture_screenshot "08-storage-card-highlighted"
     emu_key Return
     sleep 2
-    capture_screenshot "07-storage-card-contents"
+    capture_screenshot "09-storage-card-contents"
 
     # Step 6: Navigate to navit.exe
-    # Storage Card contents (sorted alphabetically, folders first):
-    #   Folders: 2577, espeak-data, icons, locale, maps (5 folders)
-    #   Files: autorun.exe, navit.exe, navit.xml, navit_layout_*.xml, ...
-    # navit.exe is the 7th item (5 folders + autorun.exe + navit.exe)
-    log "Step 6: Navigating to navit.exe (7x Down)..."
+    # Storage Card (sorted, folders first):
+    #   1. 2577/        (folder)
+    #   2. espeak-data/ (folder)
+    #   3. icons/       (folder)
+    #   4. locale/      (folder)
+    #   5. maps/        (folder)
+    #   6. autorun.exe  (file)
+    #   7. navit.exe    (file) ← target (7 Down, or 6 if first item auto-selected)
+    log "Step 6: Navigating to navit.exe..."
     for i in 1 2 3 4 5 6 7; do
         emu_key Down
     done
     sleep 0.5
-    capture_screenshot "08-navit-highlighted"
+    capture_screenshot "10-navit-highlighted"
     emu_key Return
     sleep 5
-    capture_screenshot "09-navit-launched"
+    capture_screenshot "11-navit-launched"
 
-    import -window root "$RESULTS_DIR/10-root-state-$(date '+%H%M%S').png" 2>/dev/null || true
+    import -window root "$RESULTS_DIR/12-root-state-$(date '+%H%M%S').png" 2>/dev/null || true
     log "GUI navigation complete"
 fi
 
 # --- Wait for Navit to potentially start ---
 log "Waiting 20s for Navit to initialize..."
 sleep 20
-capture_screenshot "11-after-wait"
+capture_screenshot "13-after-wait"
 
 # --- Monitor for remaining time ---
 REMAINING=$((SMOKE_TIMEOUT - (SECONDS - START)))

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -186,75 +186,99 @@ emu_click 50 170
 sleep 3
 capture_screenshot "03-programs-tapped"
 
-# Step 3: Tap File Explorer in the Programs grid
+# Step 3: Double-tap File Explorer in the Programs grid
 # From screenshot analysis of the Programs screen:
-#   Grid layout (3 columns x 4 rows visible):
-#     Row 1 (y~90):  Games(x~40), ActiveSync(x~120), Calculator(x~190)
-#     Row 2 (y~160): File Explorer(x~40), Getting Started(x~120), Internet Sharing(x~190)
-#     Row 3 (y~230): Messenger(x~40), Notes(x~120), Pictures & Videos(x~190)
-#     Row 4 (y~300): Search(x~40), SimTkUI(x~120), Task Manager(x~190)
-log "Step 3: Tapping File Explorer..."
-emu_click 40 160
+#   Grid layout (3 columns x 4 rows):
+#     Row 1 (icon y~65, label y~85): Games(x~40), ActiveSync(x~120), Calculator(x~190)
+#     Row 2 (icon y~140, label y~162): File Explorer(x~40), Getting Started(x~120), Internet Sharing(x~190)
+#     Row 3 (icon y~210): Messenger(x~40), Notes(x~120), Pictures & Videos(x~190)
+#     Row 4 (icon y~280): Search(x~40), SimTkUI(x~120), Task Manager(x~190)
+# Single tap selects, double-tap opens.
+log "Step 3: Double-tapping File Explorer icon..."
+emu_dblclick 40 145
 sleep 3
-capture_screenshot "04-file-explorer"
+capture_screenshot "04-after-file-explorer-dblclick"
 
-# Step 4: In File Explorer, navigate to Storage Card
-# File Explorer shows the \My Device root with items like:
-#   My Documents, Program Files, Storage Card, Temp, Windows, etc.
-# Items are in a list view. "Storage Card" should be visible.
-# List items start around y=35 with ~20px spacing.
-log "Step 4: Looking for Storage Card in File Explorer..."
-capture_screenshot "05-file-explorer-view"
+# Check if we got File Explorer or are still on Programs
+# If still on Programs, try clicking the File Explorer text label
+log "Step 3b: Trying File Explorer label area..."
+emu_dblclick 40 165
+sleep 3
+capture_screenshot "05-after-label-dblclick"
 
-# Scroll down if needed and try tapping "Storage Card"
-# It's typically several items down in the list
-# Try tapping items from top to bottom until we find it
-emu_click 120 80
-sleep 2
-capture_screenshot "06a-fe-item1"
+# Step 4: Navigate File Explorer to Storage Card
+# File Explorer shows \My Device root. Items in list view with ~20px rows.
+# Typical items: My Documents, Program Files, Storage Card, Temp, Windows
+# "Storage Card" is the shared folder from /sharedfolder flag.
+log "Step 4: Navigating to Storage Card..."
+capture_screenshot "06-current-view"
 
-emu_click 120 100
-sleep 2
-capture_screenshot "06b-fe-item2"
+# Tap through the list looking for Storage Card
+# In File Explorer list, folders appear with folder icons, ~20px spacing
+# starting around y=35 below the address bar
+emu_click 120 55
+sleep 1
+capture_screenshot "06a-item1"
 
-emu_click 120 120
-sleep 2
-capture_screenshot "06c-fe-item3"
+emu_click 120 75
+sleep 1
+capture_screenshot "06b-item2"
 
-emu_click 120 140
-sleep 2
-capture_screenshot "06d-fe-item4"
+emu_click 120 95
+sleep 1
+capture_screenshot "06c-item3"
 
-emu_click 120 160
-sleep 2
-capture_screenshot "06e-fe-item5"
+emu_click 120 115
+sleep 1
+capture_screenshot "06d-item4"
 
-# Step 5: In Storage Card folder, find and tap navit.exe
+emu_click 120 135
+sleep 1
+capture_screenshot "06e-item5"
+
+emu_click 120 155
+sleep 1
+capture_screenshot "06f-item6"
+
+emu_click 120 175
+sleep 1
+capture_screenshot "06g-item7"
+
+# Step 5: Find and tap navit.exe in Storage Card
 log "Step 5: Looking for navit.exe..."
-capture_screenshot "07-storage-card-contents"
+capture_screenshot "07-looking-for-navit"
 
-# navit.exe should be one of the items in the folder
-# The build produces: navit.exe, navit.xml, icons/, locale/, espeak-data/, maps/
-emu_click 120 60
-sleep 2
-capture_screenshot "08a-item1"
+# The shared folder contains: espeak-data/, icons/, locale/, maps/,
+# navit.exe, navit.xml, navit_layout_*.xml
+# navit.exe should be after the folders alphabetically
+emu_click 120 55
+sleep 1
+capture_screenshot "07a-try1"
 
-emu_click 120 80
-sleep 2
-capture_screenshot "08b-item2"
+emu_click 120 75
+sleep 1
+capture_screenshot "07b-try2"
 
-emu_click 120 100
-sleep 2
-capture_screenshot "08c-item3"
+emu_click 120 95
+sleep 1
+capture_screenshot "07c-try3"
 
-emu_click 120 120
-sleep 2
-capture_screenshot "08d-item4"
+emu_click 120 115
+sleep 1
+capture_screenshot "07d-try4"
+
+emu_click 120 135
+sleep 1
+capture_screenshot "07e-try5"
+
+emu_click 120 155
+sleep 1
+capture_screenshot "07f-try6"
 
 # Give Navit time to start and render
 log "Waiting 15s for Navit to initialize..."
 sleep 15
-capture_screenshot "09-navit-running"
+capture_screenshot "08-navit-result"
 
 # --- Monitor for remaining time ---
 REMAINING=$((SMOKE_TIMEOUT - (SECONDS - START)))

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -176,22 +176,24 @@ fi
 
 # Rotate screen if requested. Device Emulator doesn't support /rotate CLI flag.
 # Use the Wine menu bar: Flash > Rotate Right (each = 90 degrees clockwise).
-# Wine menu bar is at screen y≈12. "Flash" text center is at screen x≈50.
+# Window-relative coords: menu bar at y≈12, "Flash" at x≈50.
 if [ "$ROTATE" != "0" ]; then
     log "Rotating screen $ROTATE x 90 degrees via Flash menu..."
     for i in $(seq 1 "$ROTATE"); do
-        # Click "Flash" in the Wine menu bar (screen coords, not WM coords)
-        xdotool mousemove 50 12
+        # Click "Flash" in the Wine menu bar (window-relative coords)
+        xdotool mousemove --window "$WIN_ID" 50 12
         sleep 0.3
         xdotool mousedown 1; sleep 0.1; xdotool mouseup 1
         sleep 1
         capture_screenshot "00-flash-menu-$i"
-        # Click "Rotate Right" — first item or second item in dropdown
-        # Estimate dropdown item at ~screen(50, 30) for first item, (50, 45) for second
-        xdotool mousemove 80 45
+        # Click "Rotate Right" in the dropdown menu
+        # Dropdown items appear below the menu bar, ~18px each
+        # Try first few positions to find Rotate Right
+        xdotool mousemove --window "$WIN_ID" 80 30
         sleep 0.2
         xdotool mousedown 1; sleep 0.1; xdotool mouseup 1
         sleep 2
+        capture_screenshot "00-rotate-click-$i"
     done
     sleep 3
     capture_screenshot "00-after-rotate"

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -30,8 +30,15 @@ log() { echo "[$(date '+%H:%M:%S')] $*" | tee -a "$RESULTS_DIR/smoke-test.log"; 
 capture_screenshot() {
     local label="${1:-screenshot}"
     local outfile="$RESULTS_DIR/${label}-$(date '+%H%M%S').png"
-    import -window root "$outfile" 2>/dev/null && \
-        log "Screenshot: $outfile" || true
+    local wid
+    wid="$(xdotool search --name 'Device Emulator' 2>/dev/null | head -1 || true)"
+    if [ -n "$wid" ]; then
+        import -window "$wid" "$outfile" 2>/dev/null && \
+            log "Screenshot: $outfile" || true
+    else
+        import -window root "$outfile" 2>/dev/null && \
+            log "Screenshot (root): $outfile" || true
+    fi
 }
 
 # Click inside the WM screen area of the emulator.

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -192,9 +192,9 @@ if [ "$ROTATE" = "1" ] || [ "$ROTATE" = "3" ]; then
     sleep 3
     capture_screenshot "02-start-tapped"
 
-    # Step 2: Tap "Programs" (verified from landscape screenshot)
+    # Step 2: Tap "Programs" (WM(50,170) verified working in landscape v6 run)
     log "Step 2: Tapping Programs..."
-    emu_click 50 150
+    emu_click 50 170
     sleep 3
     capture_screenshot "03-programs-tapped"
 

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -83,7 +83,7 @@ log "Navit package: $(find "$NAVIT_DIR" -type f | wc -l) files"
 
 # --- Start Xvfb ---
 log "Starting Xvfb..."
-Xvfb :99 -screen 0 800x600x24 &
+Xvfb :99 -screen 0 320x480x24 &
 XVFB_PID=$!
 export DISPLAY=:99
 sleep 2

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -35,6 +35,32 @@ capture_screenshot() {
         log "Screenshot: $outfile" || true
 }
 
+# Click at coordinates relative to the emulator window
+emu_click() {
+    local x="$1" y="$2"
+    local win_id
+    win_id="$(xdotool search --name 'Device Emulator' 2>/dev/null | head -1 || \
+              xdotool search --name 'Pocket PC' 2>/dev/null | head -1 || true)"
+    if [ -n "$win_id" ]; then
+        # Get window geometry to find the offset
+        local wx wy
+        eval "$(xdotool getwindowgeometry --shell "$win_id" 2>/dev/null || true)"
+        wx="${X:-0}"
+        wy="${Y:-0}"
+        # The WM screen starts below the Wine menu bar (~20px)
+        # Coordinates are relative to the WM screen area
+        local abs_x=$((wx + x))
+        local abs_y=$((wy + 20 + y))
+        log "Click at WM($x,$y) -> screen($abs_x,$abs_y)"
+        xdotool mousemove "$abs_x" "$abs_y"
+        sleep 0.2
+        xdotool click 1
+        sleep 1
+    else
+        log "WARNING: Could not find emulator window for click"
+    fi
+}
+
 cleanup() {
     log "Cleaning up..."
     [ -n "${EMU_PID:-}" ] && kill "$EMU_PID" 2>/dev/null && sleep 1 && kill -9 "$EMU_PID" 2>/dev/null || true
@@ -61,7 +87,6 @@ kill -0 "$XVFB_PID" 2>/dev/null || { log "FATAL: Xvfb failed to start"; exit 1; 
 
 # --- Initialize Wine ---
 log "Initializing Wine prefix..."
-# Timeout wineboot — it can hang downloading mono/gecko even with WINEDLLOVERRIDES
 timeout 60 wineboot --init 2>/dev/null || {
     log "WARNING: wineboot timed out or failed (exit $?) — continuing anyway"
 }
@@ -98,9 +123,7 @@ while [ $((SECONDS - START)) -lt "$BOOT_TIMEOUT" ]; do
         exit 1
     fi
 
-    # Search for emulator window by various possible titles
     if xdotool search --name "Device Emulator" 2>/dev/null | grep -q . || \
-       xdotool search --name "Windows Mobile" 2>/dev/null | grep -q . || \
        xdotool search --name "Pocket PC" 2>/dev/null | grep -q .; then
         BOOTED=true
         log "Emulator window detected after $((SECONDS - START))s"
@@ -110,14 +133,12 @@ while [ $((SECONDS - START)) -lt "$BOOT_TIMEOUT" ]; do
     sleep 2
 done
 
-capture_screenshot "boot"
-
 if ! $BOOTED; then
-    # Process alive but no window — might still be OK (rendering offscreen or unknown title)
     if kill -0 "$EMU_PID" 2>/dev/null; then
         log "WARNING: No window detected but process alive — continuing"
     else
         log "FATAL: No window and process dead"
+        capture_screenshot "crash"
         exit 1
     fi
 fi
@@ -127,34 +148,87 @@ log "Waiting 20s for WM to stabilize..."
 sleep 20
 capture_screenshot "post-boot"
 
-# Check process still alive after boot
 if ! kill -0 "$EMU_PID" 2>/dev/null; then
     log "Device Emulator died after boot"
     tail -30 "$RESULTS_DIR/wine-output.log" | tee -a "$RESULTS_DIR/smoke-test.log"
     exit 1
 fi
 
+# --- Launch Navit via xdotool clicks ---
+# The WM 6.1 Professional emulator has a 240x320 screen.
+# We need to navigate: Start > File Explorer > Storage Card > navit.exe
+#
+# Coordinate reference (relative to WM screen area, 240x320):
+#   Start button: top-left area (~30, 7)
+#   Start menu items vary by position
+#
+# Alternative approach: use the emulator's File menu to run a command,
+# or navigate via File Explorer.
+#
+# Strategy: Click Start > Programs > File Explorer, then navigate to
+# Storage Card and tap navit.exe. Coordinates are approximate and may
+# need tuning based on actual menu layout.
+
+log "Attempting to launch Navit inside emulator..."
+
+# Step 1: Click "Start" in the WM taskbar (top-left of WM screen)
+log "Step 1: Clicking Start..."
+emu_click 30 7
+sleep 2
+capture_screenshot "start-menu"
+
+# Step 2: Click "Programs" in the Start menu
+# In WM6.1 Professional, "Programs" is typically near the bottom of the Start menu
+log "Step 2: Clicking Programs..."
+emu_click 120 280
+sleep 2
+capture_screenshot "programs-menu"
+
+# Step 3: Look for File Explorer in Programs
+# File Explorer is typically in the Programs list
+log "Step 3: Clicking File Explorer..."
+emu_click 120 120
+sleep 2
+capture_screenshot "file-explorer"
+
+# Step 4: In File Explorer, look for "Storage Card" (the shared folder)
+log "Step 4: Looking for Storage Card..."
+emu_click 120 80
+sleep 2
+capture_screenshot "storage-card"
+
+# Step 5: Look for navit.exe
+log "Step 5: Looking for navit.exe..."
+emu_click 120 80
+sleep 2
+capture_screenshot "navit-click"
+
+# Give Navit time to start
+log "Waiting 10s for Navit to initialize..."
+sleep 10
+capture_screenshot "navit-startup"
+
 # --- Monitor for remaining time ---
 REMAINING=$((SMOKE_TIMEOUT - (SECONDS - START)))
-log "Monitoring for ${REMAINING}s more..."
-LAST_SHOT=$SECONDS
+if [ "$REMAINING" -gt 0 ]; then
+    log "Monitoring for ${REMAINING}s more..."
+    LAST_SHOT=$SECONDS
 
-while [ $((SECONDS - START)) -lt "$SMOKE_TIMEOUT" ]; do
-    if ! kill -0 "$EMU_PID" 2>/dev/null; then
-        log "Device Emulator exited during monitoring"
-        wait "$EMU_PID" 2>/dev/null || true
-        capture_screenshot "exit"
-        # Exiting during monitoring is a failure — the emulator should stay alive
-        exit 1
-    fi
+    while [ $((SECONDS - START)) -lt "$SMOKE_TIMEOUT" ]; do
+        if ! kill -0 "$EMU_PID" 2>/dev/null; then
+            log "Device Emulator exited during monitoring"
+            capture_screenshot "exit"
+            exit 1
+        fi
 
-    if [ $((SECONDS - LAST_SHOT)) -ge 20 ]; then
-        capture_screenshot "monitor"
-        LAST_SHOT=$SECONDS
-    fi
+        if [ $((SECONDS - LAST_SHOT)) -ge 20 ]; then
+            capture_screenshot "monitor"
+            LAST_SHOT=$SECONDS
+        fi
 
-    sleep 5
-done
+        sleep 5
+    done
+fi
 
 # --- Final ---
 capture_screenshot "final"

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -242,19 +242,19 @@ sleep 3
 capture_screenshot "06d-storage-card"
 
 # Step 5: Find and tap navit.exe in Storage Card
-# The shared folder contains (folders first, then files alphabetically):
-#   espeak-data/   y≈57
-#   icons/         y≈75
-#   locale/        y≈93
-#   maps/          y≈111
-#   navit.exe      y≈129
-#   navit.xml      y≈147
-#   navit_layout_* y≈165+
+# From screenshot analysis of Storage Card listing (06d):
+#   espeak-data/      y≈57  (folder)
+#   icons/            y≈75  (folder)
+#   locale/           y≈93  (folder)
+#   navit  7.93M      y≈111 (navit.exe)
+#   navit  30.7K      y≈129 (navit.xml - opens in IE!)
+#   navit  5.46M      y≈147
+#   navit_layout_*    y≈165+
 log "Step 5: Looking for navit.exe..."
 capture_screenshot "07-folder-contents"
 
-# navit.exe should be the 5th item (after 4 folders)
-emu_click 120 129
+# navit.exe (7.93M) is the 4th item (after 3 folders, no maps/ folder)
+emu_click 120 111
 sleep 3
 capture_screenshot "07a-click-navit-exe"
 

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# WinCE Smoke Test: Boot Device Emulator under Wine+Xvfb, launch Navit, verify startup.
+#
+# Expects:
+#   emulator/DeviceEmulator.exe  — from wince-setup-emulator.sh
+#   emulator/rom.bin             — from wince-setup-emulator.sh
+#   navit-package/navit.exe      — from build_wince artifact
+#
+# Environment:
+#   EMU_DIR        - emulator directory (default: emulator)
+#   NAVIT_DIR      - navit package directory (default: navit-package)
+#   SMOKE_TIMEOUT  - total timeout in seconds (default: 120)
+
+set -euo pipefail
+
+EMU_DIR="${EMU_DIR:-emulator}"
+NAVIT_DIR="${NAVIT_DIR:-navit-package}"
+RESULTS_DIR="smoke-results"
+SMOKE_TIMEOUT="${SMOKE_TIMEOUT:-120}"
+
+export WINEPREFIX="$PWD/.wine-emu"
+export WINEARCH=win32
+export WINEDEBUG="-all,+err"
+
+mkdir -p "$RESULTS_DIR"
+
+log() { echo "[$(date '+%H:%M:%S')] $*" | tee -a "$RESULTS_DIR/smoke-test.log"; }
+
+capture_screenshot() {
+    local label="${1:-screenshot}"
+    local outfile="$RESULTS_DIR/${label}-$(date '+%H%M%S').png"
+    import -window root "$outfile" 2>/dev/null && \
+        log "Screenshot: $outfile" || true
+}
+
+cleanup() {
+    log "Cleaning up..."
+    [ -n "${EMU_PID:-}" ] && kill "$EMU_PID" 2>/dev/null && sleep 1 && kill -9 "$EMU_PID" 2>/dev/null || true
+    [ -n "${XVFB_PID:-}" ] && kill "$XVFB_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# --- Validate inputs ---
+[ -f "$EMU_DIR/DeviceEmulator.exe" ] || { log "FATAL: $EMU_DIR/DeviceEmulator.exe not found"; exit 1; }
+[ -f "$EMU_DIR/rom.bin" ] || { log "FATAL: $EMU_DIR/rom.bin not found"; exit 1; }
+[ -f "$NAVIT_DIR/navit.exe" ] || { log "FATAL: $NAVIT_DIR/navit.exe not found"; exit 1; }
+
+log "DeviceEmulator.exe: $(du -h "$EMU_DIR/DeviceEmulator.exe" | cut -f1)"
+log "rom.bin: $(du -h "$EMU_DIR/rom.bin" | cut -f1)"
+log "Navit package: $(find "$NAVIT_DIR" -type f | wc -l) files"
+
+# --- Start Xvfb ---
+log "Starting Xvfb..."
+Xvfb :99 -screen 0 800x600x24 &
+XVFB_PID=$!
+export DISPLAY=:99
+sleep 2
+kill -0 "$XVFB_PID" 2>/dev/null || { log "FATAL: Xvfb failed to start"; exit 1; }
+
+# --- Initialize Wine ---
+log "Initializing Wine prefix..."
+wineboot --init 2>/dev/null
+wineserver --wait 2>/dev/null || true
+
+# --- Convert paths to Windows format ---
+EMU_WIN="$(winepath -w "$(realpath "$EMU_DIR/DeviceEmulator.exe")")"
+ROM_WIN="$(winepath -w "$(realpath "$EMU_DIR/rom.bin")")"
+SHARE_WIN="$(winepath -w "$(realpath "$NAVIT_DIR")")"
+
+# --- Launch Device Emulator ---
+log "Launching: wine $EMU_WIN $ROM_WIN /memsize 128 /sharedfolder $SHARE_WIN"
+
+wine "$EMU_DIR/DeviceEmulator.exe" \
+    "$ROM_WIN" \
+    /memsize 128 \
+    /sharedfolder "$SHARE_WIN" \
+    > "$RESULTS_DIR/wine-output.log" 2>&1 &
+EMU_PID=$!
+log "Device Emulator PID: $EMU_PID"
+
+# --- Wait for emulator window ---
+BOOT_TIMEOUT=60
+log "Waiting up to ${BOOT_TIMEOUT}s for emulator window..."
+START=$SECONDS
+BOOTED=false
+
+while [ $((SECONDS - START)) -lt "$BOOT_TIMEOUT" ]; do
+    if ! kill -0 "$EMU_PID" 2>/dev/null; then
+        log "Device Emulator died during boot"
+        tail -30 "$RESULTS_DIR/wine-output.log" | tee -a "$RESULTS_DIR/smoke-test.log"
+        capture_screenshot "crash"
+        exit 1
+    fi
+
+    # Search for emulator window by various possible titles
+    if xdotool search --name "Device Emulator" 2>/dev/null | grep -q . || \
+       xdotool search --name "Windows Mobile" 2>/dev/null | grep -q . || \
+       xdotool search --name "Pocket PC" 2>/dev/null | grep -q .; then
+        BOOTED=true
+        log "Emulator window detected after $((SECONDS - START))s"
+        break
+    fi
+
+    sleep 2
+done
+
+capture_screenshot "boot"
+
+if ! $BOOTED; then
+    # Process alive but no window — might still be OK (rendering offscreen or unknown title)
+    if kill -0 "$EMU_PID" 2>/dev/null; then
+        log "WARNING: No window detected but process alive — continuing"
+    else
+        log "FATAL: No window and process dead"
+        exit 1
+    fi
+fi
+
+# --- Let WM finish booting ---
+log "Waiting 20s for WM to stabilize..."
+sleep 20
+capture_screenshot "post-boot"
+
+# Check process still alive after boot
+if ! kill -0 "$EMU_PID" 2>/dev/null; then
+    log "Device Emulator died after boot"
+    tail -30 "$RESULTS_DIR/wine-output.log" | tee -a "$RESULTS_DIR/smoke-test.log"
+    exit 1
+fi
+
+# --- Monitor for remaining time ---
+REMAINING=$((SMOKE_TIMEOUT - (SECONDS - START)))
+log "Monitoring for ${REMAINING}s more..."
+LAST_SHOT=$SECONDS
+
+while [ $((SECONDS - START)) -lt "$SMOKE_TIMEOUT" ]; do
+    if ! kill -0 "$EMU_PID" 2>/dev/null; then
+        log "Device Emulator exited during monitoring"
+        wait "$EMU_PID" 2>/dev/null || true
+        capture_screenshot "exit"
+        # Exiting during monitoring is a failure — the emulator should stay alive
+        exit 1
+    fi
+
+    if [ $((SECONDS - LAST_SHOT)) -ge 20 ]; then
+        capture_screenshot "monitor"
+        LAST_SHOT=$SECONDS
+    fi
+
+    sleep 5
+done
+
+# --- Final ---
+capture_screenshot "final"
+
+if kill -0 "$EMU_PID" 2>/dev/null; then
+    log "PASS: Device Emulator survived ${SMOKE_TIMEOUT}s"
+else
+    log "FAIL: Device Emulator died before timeout"
+    exit 1
+fi
+
+# Collect any Navit logs from the shared folder
+find "$NAVIT_DIR" -name "*.log" -exec cp {} "$RESULTS_DIR/" \; 2>/dev/null || true
+ps aux > "$RESULTS_DIR/processes.txt" 2>/dev/null || true
+
+log "Results in $RESULTS_DIR/"
+ls -la "$RESULTS_DIR/"
+exit 0

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -50,20 +50,6 @@ emu_key() {
     sleep 0.3
 }
 
-# Tap a point on the WinCE guest screen.
-# Guest coordinates are relative to the WinCE display area,
-# which starts below the host menu bar (~19px).
-MENU_BAR_H=19
-tap_guest() {
-    local gx="$1" gy="$2" label="${3:-}"
-    local wx=$gx
-    local wy=$((gy + MENU_BAR_H))
-    [ -n "$label" ] && log "Tap ($gx,$gy) [${label}]"
-    xdotool mousemove --window "$EMU_WID" "$wx" "$wy"
-    sleep 0.3
-    xdotool click --window "$EMU_WID" 1
-}
-
 cleanup() {
     log "Cleaning up..."
     [ -n "${EMU_PID:-}" ] && kill "$EMU_PID" 2>/dev/null && sleep 1 && kill -9 "$EMU_PID" 2>/dev/null || true
@@ -150,8 +136,20 @@ fi
 
 # --- Launch Navit via WinCE File Explorer ---
 # Navigate: Start > Programs > File Explorer > Storage Card > navit.exe
-# Use keyboard navigation (arrow keys + Enter) which works regardless of
-# screen orientation, instead of fragile pixel-coordinate tapping.
+# Use keyboard navigation (Super, arrows, Enter).
+#
+# Start menu layout (from CI screenshots):
+#   Today, Office Mobile, Calendar, Contacts, Internet Explorer, Messaging,
+#   [Recent Programs header], Programs, Settings, Help
+#   → 6 Down presses to reach Programs
+#
+# Programs screen grid layout (4 columns):
+#   Row 1: Games | ActiveSync | Calculator | File Explorer
+#   Row 2: Getting Started | Internet Sharing | Messenger | Notes
+#   Row 3: Pictures & Videos | Search | SimTkUI | Task Manager
+#   Row 4: Tasks | Windows | Windows
+#   → Default selection: Games (row 1, col 1)
+#   → File Explorer: 3 Right presses
 log "Navigating WinCE GUI to launch navit.exe..."
 
 if [ -z "$EMU_WID" ]; then
@@ -160,108 +158,84 @@ else
     xdotool windowfocus "$EMU_WID" 2>/dev/null || true
     sleep 0.5
 
-    # Step 1: Open Start menu
-    # Try multiple approaches: F1 (left softkey = Start in PPC),
-    # Windows/Super key, and direct tap on Start button.
-    log "Step 1: Opening Start menu..."
-
-    # Try F1 first (left softkey, which is "Start" on Today screen)
-    emu_key F1
-    sleep 1
-    capture_screenshot "02-after-F1"
-
-    # Also try tapping the Start button area at the top-left
-    # The WinCE nav bar "Start" is at approximately guest (15, 5)
-    tap_guest 15 5 "Start button tap"
-    sleep 1
-    capture_screenshot "03-after-start-tap"
-
-    # Try Windows/Super key as another approach
+    # Step 1: Open Start menu with Super (Windows) key
+    log "Step 1: Opening Start menu (Super key)..."
     emu_key super
     sleep 1
-    capture_screenshot "04-after-super"
+    capture_screenshot "02-start-menu"
 
-    # Step 2: Navigate to Programs using keyboard
-    # PPC Start menu items (from landscape screenshot):
-    #   1. Today (selected by default)
-    #   2. Office Mobile
-    #   3. Calendar
-    #   4. Contacts
-    #   5. Internet Explorer
-    #   6. Messaging
-    #   7. Programs  <-- target (6 Down presses from Today)
+    # Step 2: Navigate to Programs (6x Down + Enter)
     log "Step 2: Navigating to Programs..."
     for i in 1 2 3 4 5 6; do
         emu_key Down
     done
     sleep 0.5
-    capture_screenshot "05-programs-highlight"
-
-    # Press Enter to open Programs
+    capture_screenshot "03-programs-highlight"
     emu_key Return
     sleep 2
-    capture_screenshot "06-programs-screen"
+    capture_screenshot "04-programs-screen"
 
-    # Step 3: Find and open File Explorer in Programs screen
-    # Programs screen shows a grid of program icons.
-    # We need to navigate to File Explorer.
-    # In PPC 2003 SE, Programs typically shows:
-    #   Row 1: Games, Calculator, ...
-    #   File Explorer might be in the list view.
-    # Try keyboard navigation: Tab/arrows to find File Explorer.
-    # First, let's just take a screenshot and see what we have.
-    # Try pressing Down a few times to find File Explorer.
-    log "Step 3: Looking for File Explorer..."
-
-    # In the Programs screen, items may be in a grid.
-    # Try navigating with arrow keys.
-    for i in 1 2 3; do
-        emu_key Down
-    done
+    # Step 3: Navigate to File Explorer (3x Right + Enter)
+    # Grid layout: Games is selected by default (row 1, col 1).
+    # File Explorer is at row 1, col 4 → 3 Right presses.
+    log "Step 3: Navigating to File Explorer..."
+    emu_key Right
+    emu_key Right
+    emu_key Right
     sleep 0.5
-    capture_screenshot "07-programs-nav"
-
-    # Try selecting the current item
+    capture_screenshot "05-file-explorer-highlight"
     emu_key Return
     sleep 2
-    capture_screenshot "08-after-programs-select"
+    capture_screenshot "06-file-explorer"
 
-    # Step 4: If we're in File Explorer, look for Storage Card
-    # If not, we need to adjust. Take screenshots to diagnose.
-    log "Step 4: Looking for Storage Card..."
-    # In File Explorer list view, navigate down to find Storage Card
-    for i in 1 2 3 4 5; do
-        emu_key Down
-    done
+    # Step 4: Navigate to Storage Card in File Explorer
+    # File Explorer opens showing "My Device" contents.
+    # Folders listed alphabetically: My Documents, Program Files,
+    # Storage Card, Temp, Windows, etc.
+    # "Storage Card" is typically the 3rd or 4th item.
+    # Navigate down and look for it.
+    log "Step 4: Navigating to Storage Card..."
+    # First item might be selected or we might need to move into the list.
+    # Try Down a few times to reach Storage Card.
+    emu_key Down
+    emu_key Down
+    emu_key Down
     sleep 0.5
-    capture_screenshot "09-file-list"
-
-    # Open selected item
+    capture_screenshot "07-storage-card-highlight"
     emu_key Return
     sleep 2
-    capture_screenshot "10-after-open"
+    capture_screenshot "08-storage-card-contents"
 
-    # Step 5: Look for navit.exe in Storage Card
+    # Step 5: Find and open navit.exe in Storage Card
+    # The Storage Card contains navit package files.
+    # Folders come first (2577, espeak-data, icons, locale, maps),
+    # then files alphabetically.
+    # navit.exe is in the file list after the folders.
+    # Need to navigate past folders to find navit.exe.
     log "Step 5: Looking for navit.exe..."
-    # Navigate through file list
-    for i in 1 2 3; do
+    # Navigate down through the file list.
+    # Folders: 2577, espeak-data, icons, locale, maps = 5 folders
+    # Then files: autorun.exe, navit.exe, navit.xml, ...
+    # navit.exe should be ~7 items down (5 folders + autorun.exe + navit.exe)
+    for i in 1 2 3 4 5 6 7; do
         emu_key Down
     done
     sleep 0.5
+    capture_screenshot "09-navit-highlight"
 
     # Open navit.exe
     emu_key Return
-    sleep 3
-    capture_screenshot "11-navit-attempt"
+    sleep 5
+    capture_screenshot "10-navit-launched"
 
-    import -window root "$RESULTS_DIR/12-root-state-$(date '+%H%M%S').png" 2>/dev/null || true
+    import -window root "$RESULTS_DIR/11-root-state-$(date '+%H%M%S').png" 2>/dev/null || true
     log "GUI navigation complete"
 fi
 
 # --- Wait for Navit to potentially start ---
 log "Waiting 20s for Navit to initialize..."
 sleep 20
-capture_screenshot "13-after-wait"
+capture_screenshot "12-after-wait"
 
 # --- Monitor for remaining time ---
 REMAINING=$((SMOKE_TIMEOUT - (SECONDS - START)))

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -50,6 +50,16 @@ emu_key() {
     sleep 0.3
 }
 
+# Tap a point on the WinCE guest screen (guest coords).
+MENU_BAR_H=19
+tap_guest() {
+    local gx="$1" gy="$2" label="${3:-}"
+    [ -n "$label" ] && log "Tap ($gx,$gy) [${label}]"
+    xdotool mousemove --window "$EMU_WID" "$gx" "$((gy + MENU_BAR_H))"
+    sleep 0.3
+    xdotool click --window "$EMU_WID" 1
+}
+
 cleanup() {
     log "Cleaning up..."
     [ -n "${EMU_PID:-}" ] && kill "$EMU_PID" 2>/dev/null && sleep 1 && kill -9 "$EMU_PID" 2>/dev/null || true
@@ -135,21 +145,26 @@ if ! kill -0 "$EMU_PID" 2>/dev/null; then
 fi
 
 # --- Launch Navit via WinCE File Explorer ---
-# Navigate: Start > Programs > File Explorer > Storage Card > navit.exe
-# Use keyboard navigation (Super, arrows, Enter).
+# Navigate: Start > Programs > File Explorer > [up to root] > Storage Card > navit.exe
 #
-# Start menu layout (from CI screenshots):
+# Keyboard navigation:
+#   Super      → opens Start menu
+#   Down x6    → highlights "Programs"
+#   Return     → opens Programs screen
+#   Right x3   → highlights "File Explorer" (grid: row1 col4)
+#   Return     → opens File Explorer (defaults to My Documents)
+#   Backspace  → goes up to My Device root
+#   Down to "Storage Card" → Enter → navigate to navit.exe → Enter
+#
+# The Start menu layout (confirmed from landscape CI screenshots):
 #   Today, Office Mobile, Calendar, Contacts, Internet Explorer, Messaging,
-#   [Recent Programs header], Programs, Settings, Help
-#   → 6 Down presses to reach Programs
+#   [Recent Programs header - not selectable],
+#   Programs, Settings, Help
 #
-# Programs screen grid layout (4 columns):
+# Programs grid layout (4 columns, confirmed from CI screenshots):
 #   Row 1: Games | ActiveSync | Calculator | File Explorer
 #   Row 2: Getting Started | Internet Sharing | Messenger | Notes
-#   Row 3: Pictures & Videos | Search | SimTkUI | Task Manager
-#   Row 4: Tasks | Windows | Windows
-#   → Default selection: Games (row 1, col 1)
-#   → File Explorer: 3 Right presses
+#   ...
 log "Navigating WinCE GUI to launch navit.exe..."
 
 if [ -z "$EMU_WID" ]; then
@@ -165,77 +180,78 @@ else
     capture_screenshot "02-start-menu"
 
     # Step 2: Navigate to Programs (6x Down + Enter)
-    log "Step 2: Navigating to Programs..."
+    # From CI: Today is first, Programs is 7th selectable item (6 Down)
+    log "Step 2: Navigating to Programs (6x Down)..."
     for i in 1 2 3 4 5 6; do
         emu_key Down
     done
     sleep 0.5
-    capture_screenshot "03-programs-highlight"
+    capture_screenshot "03-programs-highlighted"
+
+    # Use Enter to open Programs.
+    # In PPC, the action button to open an item is typically Enter/Return.
+    log "Step 2b: Opening Programs (Enter)..."
     emu_key Return
     sleep 2
     capture_screenshot "04-programs-screen"
 
     # Step 3: Navigate to File Explorer (3x Right + Enter)
-    # Grid layout: Games is selected by default (row 1, col 1).
-    # File Explorer is at row 1, col 4 → 3 Right presses.
-    log "Step 3: Navigating to File Explorer..."
+    # Grid: Games(col1) → ActiveSync(col2) → Calculator(col3) → File Explorer(col4)
+    log "Step 3: Navigating to File Explorer (3x Right)..."
     emu_key Right
     emu_key Right
     emu_key Right
     sleep 0.5
-    capture_screenshot "05-file-explorer-highlight"
+    capture_screenshot "05-file-explorer-highlighted"
     emu_key Return
     sleep 2
-    capture_screenshot "06-file-explorer"
+    capture_screenshot "06-file-explorer-opened"
 
-    # Step 4: Navigate to Storage Card in File Explorer
-    # File Explorer opens showing "My Device" contents.
-    # Folders listed alphabetically: My Documents, Program Files,
-    # Storage Card, Temp, Windows, etc.
-    # "Storage Card" is typically the 3rd or 4th item.
-    # Navigate down and look for it.
-    log "Step 4: Navigating to Storage Card..."
-    # First item might be selected or we might need to move into the list.
-    # Try Down a few times to reach Storage Card.
-    emu_key Down
-    emu_key Down
-    emu_key Down
+    # Step 4: Navigate up from My Documents to My Device root
+    # File Explorer defaults to "My Documents". Use Backspace to go up.
+    log "Step 4: Going up to My Device root (Backspace)..."
+    emu_key BackSpace
+    sleep 1
+    capture_screenshot "07-my-device-root"
+
+    # Step 5: Navigate to Storage Card
+    # My Device root contains folders alphabetically:
+    #   My Documents, Network, Program Files, Storage Card, Temp, Windows
+    # Storage Card is typically the 4th item.
+    log "Step 5: Navigating to Storage Card..."
+    # First press Down to enter the file list, then navigate
+    for i in 1 2 3 4; do
+        emu_key Down
+    done
     sleep 0.5
-    capture_screenshot "07-storage-card-highlight"
+    capture_screenshot "08-storage-card-highlighted"
     emu_key Return
     sleep 2
-    capture_screenshot "08-storage-card-contents"
+    capture_screenshot "09-storage-card-contents"
 
-    # Step 5: Find and open navit.exe in Storage Card
-    # The Storage Card contains navit package files.
-    # Folders come first (2577, espeak-data, icons, locale, maps),
-    # then files alphabetically.
-    # navit.exe is in the file list after the folders.
-    # Need to navigate past folders to find navit.exe.
-    log "Step 5: Looking for navit.exe..."
-    # Navigate down through the file list.
-    # Folders: 2577, espeak-data, icons, locale, maps = 5 folders
-    # Then files: autorun.exe, navit.exe, navit.xml, ...
-    # navit.exe should be ~7 items down (5 folders + autorun.exe + navit.exe)
+    # Step 6: Find and open navit.exe
+    # Storage Card contents (from navit-package):
+    #   Folders first (alphabetical): 2577/, espeak-data/, icons/, locale/, maps/
+    #   Then files: autorun.exe, navit.exe, navit.xml, navit_layout_*.xml, ...
+    # navit.exe is the 7th item (5 folders + autorun.exe + navit.exe)
+    log "Step 6: Navigating to navit.exe..."
     for i in 1 2 3 4 5 6 7; do
         emu_key Down
     done
     sleep 0.5
-    capture_screenshot "09-navit-highlight"
-
-    # Open navit.exe
+    capture_screenshot "10-navit-highlighted"
     emu_key Return
     sleep 5
-    capture_screenshot "10-navit-launched"
+    capture_screenshot "11-navit-launched"
 
-    import -window root "$RESULTS_DIR/11-root-state-$(date '+%H%M%S').png" 2>/dev/null || true
+    import -window root "$RESULTS_DIR/12-root-state-$(date '+%H%M%S').png" 2>/dev/null || true
     log "GUI navigation complete"
 fi
 
 # --- Wait for Navit to potentially start ---
 log "Waiting 20s for Navit to initialize..."
 sleep 20
-capture_screenshot "12-after-wait"
+capture_screenshot "13-after-wait"
 
 # --- Monitor for remaining time ---
 REMAINING=$((SMOKE_TIMEOUT - (SECONDS - START)))

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -146,58 +146,85 @@ EMU_WID="$(xdotool search --name 'Device Emulator' 2>/dev/null | head -1 || true
 if [ -z "$EMU_WID" ]; then
     log "WARNING: Could not find Device Emulator window for hot-plug"
 else
-    # Focus the emulator window and open File > Configure
-    xdotool windowfocus --sync "$EMU_WID" 2>/dev/null || true
-    xdotool windowraise "$EMU_WID" 2>/dev/null || true
-    sleep 1
-    xdotool key --window "$EMU_WID" alt+f
-    sleep 1
-    capture_screenshot "02-file-menu"
-
-    # Click "Configure..." menu item (send 'c' key as accelerator)
-    xdotool key --window "$EMU_WID" c
-    sleep 2
-    capture_screenshot "03-configure-dialog"
-
-    # The Configure dialog should now be open. Find it.
-    CFG_WID="$(xdotool search --name 'Emulator Properties' 2>/dev/null | head -1 || true)"
-    if [ -z "$CFG_WID" ]; then
-        # Try alternative dialog title
-        CFG_WID="$(xdotool search --name 'Configure' 2>/dev/null | head -1 || true)"
-    fi
-    if [ -z "$CFG_WID" ]; then
-        log "WARNING: Configure dialog not found, falling back to emulator window"
-        CFG_WID="$EMU_WID"
-    fi
-    log "Configure dialog window: $CFG_WID"
-
-    # The General tab should be active by default.
-    # The Shared folder field is the last text input on the General tab.
-    # Tab through the dialog fields to reach it, then type the path.
-    # Fields: ROM image, ROM address, RAM size, Flash file, Host key, FuncKey, Shared folder
-    for i in $(seq 1 12); do
-        xdotool key --window "$CFG_WID" Tab
-        sleep 0.2
-    done
+    # Click "File" in the host menu bar using window-relative coordinates.
+    # The menu bar is rendered by Wine at the top of the window.
+    # "File" text is at approximately x=15, y=8 in the window.
+    xdotool windowfocus "$EMU_WID" 2>/dev/null || true
     sleep 0.5
 
-    # Type the Windows path to the shared folder
-    xdotool type --window "$CFG_WID" --delay 50 "$SHARE_WIN"
+    # Get window position for absolute coordinate calculation
+    eval "$(xdotool getwindowgeometry --shell "$EMU_WID" 2>/dev/null)" || true
+    log "Emulator window at X=$X Y=$Y W=${WIDTH:-?} H=${HEIGHT:-?}"
+
+    # Click on "File" menu text in the menu bar
+    xdotool mousemove --window "$EMU_WID" 15 8
+    sleep 0.3
+    xdotool click --window "$EMU_WID" 1
     sleep 1
-    capture_screenshot "04-shared-folder-set"
+    # Take a full-screen screenshot to see the menu dropdown
+    import -window root "$RESULTS_DIR/02-file-menu-$(date '+%H%M%S').png" 2>/dev/null || true
+    log "Screenshot: 02-file-menu (root)"
 
-    # Press Enter to confirm (OK button)
-    xdotool key --window "$CFG_WID" Return
+    # "Configure..." should be in the dropdown menu (a separate popup window).
+    # The dropdown appears below the menu bar at absolute screen coordinates.
+    # Menu items are ~20px tall. Configure is the 1st item under File.
+    # Calculate absolute position: window Y + menu bar height (~19px) + item offset
+    MENU_X=$((X + 15))
+    MENU_Y=$((Y + 28))
+    log "Clicking Configure at absolute ($MENU_X, $MENU_Y)"
+    xdotool mousemove "$MENU_X" "$MENU_Y"
+    sleep 0.3
+    xdotool click 1
     sleep 2
-    capture_screenshot "05-after-hotplug"
+    import -window root "$RESULTS_DIR/03-after-menu-click-$(date '+%H%M%S').png" 2>/dev/null || true
+    log "Screenshot: 03-after-menu-click (root)"
 
+    # Search for any new dialog window that appeared
+    CFG_WID=""
+    for title in "Emulator Properties" "Configure" "General"; do
+        CFG_WID="$(xdotool search --name "$title" 2>/dev/null | head -1 || true)"
+        [ -n "$CFG_WID" ] && break
+    done
+
+    if [ -n "$CFG_WID" ]; then
+        log "Configure dialog found: $CFG_WID"
+        import -window root "$RESULTS_DIR/04-configure-dialog-$(date '+%H%M%S').png" 2>/dev/null || true
+
+        # Tab through to the Shared folder field, then type the path
+        xdotool windowfocus "$CFG_WID" 2>/dev/null || true
+        sleep 0.5
+        for i in $(seq 1 12); do
+            xdotool key --window "$CFG_WID" Tab
+            sleep 0.2
+        done
+        sleep 0.5
+        xdotool type --window "$CFG_WID" --delay 50 "$SHARE_WIN"
+        sleep 1
+        import -window root "$RESULTS_DIR/05-shared-folder-set-$(date '+%H%M%S').png" 2>/dev/null || true
+
+        # Press Enter to confirm (OK button)
+        xdotool key --window "$CFG_WID" Return
+        sleep 2
+        log "Shared folder set via Configure dialog"
+    else
+        log "WARNING: Configure dialog not found. Trying keyboard shortcut approach..."
+        import -window root "$RESULTS_DIR/04-no-dialog-$(date '+%H%M%S').png" 2>/dev/null || true
+
+        # Fallback: try sending Alt+F,C via X keyboard events to the root
+        xdotool key alt+f
+        sleep 1
+        xdotool key c
+        sleep 2
+        import -window root "$RESULTS_DIR/05-fallback-$(date '+%H%M%S').png" 2>/dev/null || true
+    fi
+    capture_screenshot "06-after-hotplug"
     log "Shared folder hot-plug attempted: $SHARE_WIN"
 fi
 
 # --- Wait for autorun to trigger ---
 log "Waiting 15s for autorun.exe to launch Navit..."
 sleep 15
-capture_screenshot "06-navit-check"
+capture_screenshot "07-navit-check"
 
 # --- Monitor for remaining time ---
 REMAINING=$((SMOKE_TIMEOUT - (SECONDS - START)))

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -60,10 +60,13 @@ log "DeviceEmulator.exe: $(du -h "$EMU_DIR/DeviceEmulator.exe" | cut -f1)"
 log "rom.bin: $(du -h "$EMU_DIR/rom.bin" | cut -f1)"
 log "Navit package: $(find "$NAVIT_DIR" -type f | wc -l) files"
 
-# --- Auto-start: copy navit.exe as autorun.exe on the Storage Card ---
-# WinCE auto-executes \Storage Card\autorun.exe when the card is detected.
+# --- Auto-start: place navit.exe as autorun.exe on the Storage Card ---
+# WinCE auto-runs \Storage Card\2577\autorun.exe (2577 = ARM ARMV4I processor type)
+# when a storage card is detected. Also place in root as fallback.
+mkdir -p "$NAVIT_DIR/2577"
+cp "$NAVIT_DIR/navit.exe" "$NAVIT_DIR/2577/autorun.exe"
 cp "$NAVIT_DIR/navit.exe" "$NAVIT_DIR/autorun.exe"
-log "Created autorun.exe ($(du -h "$NAVIT_DIR/autorun.exe" | cut -f1))"
+log "Created 2577/autorun.exe and autorun.exe"
 
 # --- Start Xvfb ---
 log "Starting Xvfb (rotate=$ROTATE)..."

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -175,22 +175,33 @@ if [ -n "$WIN_ID" ]; then
 fi
 
 # Rotate screen if requested. Device Emulator doesn't support /rotate CLI flag.
-# Use the Wine menu bar: Flash > Rotate Right via keyboard navigation.
+# Keyboard goes to WM guest, so use click-drag on Wine menu bar instead.
+# Click Flash, hold, drag to dropdown item, release.
 if [ "$ROTATE" != "0" ]; then
     log "Rotating screen $ROTATE x 90 degrees via Flash menu..."
     for i in $(seq 1 "$ROTATE"); do
-        # Alt+L opens the "fLash" menu (Alt+F is File, Alt+H is Help)
-        xdotool key --window "$WIN_ID" alt+l 2>/dev/null || true
-        sleep 1
-        capture_screenshot "00-flash-menu-$i"
-        # Navigate dropdown with arrow keys and Enter
-        # Rotate Right should be one of the first items
-        xdotool key --window "$WIN_ID" Down 2>/dev/null || true
-        sleep 0.3
-        capture_screenshot "00-flash-item-$i"
-        xdotool key --window "$WIN_ID" Return 2>/dev/null || true
+        # Press-and-hold on "Flash" in Wine menu bar, drag to dropdown item
+        xdotool mousemove --window "$WIN_ID" 50 12
+        sleep 0.2
+        xdotool mousedown 1
+        sleep 0.5
+        capture_screenshot "00-flash-held-$i"
+        # Drag down to first dropdown item
+        xdotool mousemove --window "$WIN_ID" 50 28
+        sleep 0.5
+        capture_screenshot "00-flash-drag1-$i"
+        # Try second item
+        xdotool mousemove --window "$WIN_ID" 50 42
+        sleep 0.5
+        capture_screenshot "00-flash-drag2-$i"
+        # Try third item
+        xdotool mousemove --window "$WIN_ID" 50 56
+        sleep 0.5
+        capture_screenshot "00-flash-drag3-$i"
+        # Release on whichever item we're on - we'll check screenshots
+        xdotool mouseup 1
         sleep 2
-        capture_screenshot "00-rotate-click-$i"
+        capture_screenshot "00-rotate-result-$i"
     done
     sleep 3
     capture_screenshot "00-after-rotate"

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -120,13 +120,10 @@ SHARE_WIN="$(winepath -w "$(realpath "$NAVIT_DIR")")"
 # --- Launch Device Emulator ---
 log "Launching Device Emulator..."
 
-EMU_ARGS=("$ROM_WIN" /memsize 128 /sharedfolder "$SHARE_WIN")
-if [ "$ROTATE" != "0" ]; then
-    EMU_ARGS+=(/rotate "$ROTATE")
-fi
-
 wine "$EMU_DIR/DeviceEmulator.exe" \
-    "${EMU_ARGS[@]}" \
+    "$ROM_WIN" \
+    /memsize 128 \
+    /sharedfolder "$SHARE_WIN" \
     > "$RESULTS_DIR/wine-output.log" 2>&1 &
 EMU_PID=$!
 log "Device Emulator PID: $EMU_PID"
@@ -175,6 +172,29 @@ if [ -n "$WIN_ID" ]; then
     xdotool windowactivate "$WIN_ID" 2>/dev/null || true
     xdotool windowfocus "$WIN_ID" 2>/dev/null || true
     sleep 0.5
+fi
+
+# Rotate screen if requested. Device Emulator doesn't support /rotate CLI flag.
+# Use the Wine menu bar: Flash > Rotate Right (each = 90 degrees clockwise).
+# Wine menu bar is at screen y≈12. "Flash" text center is at screen x≈50.
+if [ "$ROTATE" != "0" ]; then
+    log "Rotating screen $ROTATE x 90 degrees via Flash menu..."
+    for i in $(seq 1 "$ROTATE"); do
+        # Click "Flash" in the Wine menu bar (screen coords, not WM coords)
+        xdotool mousemove 50 12
+        sleep 0.3
+        xdotool mousedown 1; sleep 0.1; xdotool mouseup 1
+        sleep 1
+        capture_screenshot "00-flash-menu-$i"
+        # Click "Rotate Right" — first item or second item in dropdown
+        # Estimate dropdown item at ~screen(50, 30) for first item, (50, 45) for second
+        xdotool mousemove 80 45
+        sleep 0.2
+        xdotool mousedown 1; sleep 0.1; xdotool mouseup 1
+        sleep 2
+    done
+    sleep 3
+    capture_screenshot "00-after-rotate"
 fi
 
 if [ "$ROTATE" = "1" ] || [ "$ROTATE" = "3" ]; then

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -174,22 +174,35 @@ else
     sleep 0.5
     import -window root "$RESULTS_DIR/03-reset-hover-$(date '+%H%M%S').png" 2>/dev/null || true
 
-    # The submenu should appear to the right. Click "Soft" (first item).
-    SUBMENU_X=$((MENU_X + 100))
-    SUBMENU_Y=$((MENU_Y))
-    log "Clicking Soft Reset at absolute ($SUBMENU_X, $SUBMENU_Y)"
-    xdotool mousemove "$SUBMENU_X" "$SUBMENU_Y"
+    # The submenu appears to the right of "Reset" with "Soft" as the first item.
+    # From screenshots: the submenu "Soft" is at roughly window-relative (155, 60).
+    # Move slowly rightward to keep the submenu open, then click "Soft".
+    xdotool mousemove --window "$EMU_WID" 100 60
     sleep 0.3
+    xdotool mousemove --window "$EMU_WID" 140 60
+    sleep 0.3
+    xdotool mousemove --window "$EMU_WID" 165 60
+    sleep 0.3
+    import -window root "$RESULTS_DIR/04-submenu-hover-$(date '+%H%M%S').png" 2>/dev/null || true
     xdotool click 1
     sleep 2
-    import -window root "$RESULTS_DIR/04-after-reset-$(date '+%H%M%S').png" 2>/dev/null || true
-    log "Soft reset triggered"
+    import -window root "$RESULTS_DIR/05-after-reset-click-$(date '+%H%M%S').png" 2>/dev/null || true
+    log "Soft reset click attempted"
+
+    # Wait for the emulator to re-detect the window after reset
+    sleep 5
+    EMU_WID2="$(xdotool search --name 'Device Emulator' 2>/dev/null | head -1 || true)"
+    if [ -n "$EMU_WID2" ]; then
+        log "Emulator window after reset: $EMU_WID2"
+    else
+        log "WARNING: Emulator window not found after reset"
+    fi
 fi
 
 # --- Wait for second boot + autorun ---
 log "Waiting 30s for WinCE to reboot and autorun.exe to launch Navit..."
 sleep 30
-capture_screenshot "05-post-reset"
+capture_screenshot "06-post-reset"
 
 # --- Monitor for remaining time ---
 REMAINING=$((SMOKE_TIMEOUT - (SECONDS - START)))

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -61,12 +61,14 @@ log "rom.bin: $(du -h "$EMU_DIR/rom.bin" | cut -f1)"
 log "Navit package: $(find "$NAVIT_DIR" -type f | wc -l) files"
 
 # --- Auto-start setup ---
-# WinCE executes all .exe files in \Storage Card\StartUp\ at end of boot.
-# Since /sharedfolder maps to \Storage Card, we create StartUp/navit.exe.
-mkdir -p "$NAVIT_DIR/StartUp"
-# Create a .lnk shortcut (WinCE text format: <charcount>#<command>)
-printf '27#\\Storage Card\\navit.exe' > "$NAVIT_DIR/StartUp/navit.lnk"
-log "Created StartUp/navit.lnk for auto-launch"
+# Place autorun.exe in the ARM processor-specific subfolder (2577 = ARMV4I).
+# WinCE shell calls SHGetAutoRunPath() when a storage card is inserted and
+# runs \Storage Card\<procID>\autorun.exe automatically.
+# We boot WITHOUT /sharedfolder and hot-plug it later via the Device Emulator's
+# File > Configure dialog so the shell sees a genuine card-insertion event.
+mkdir -p "$NAVIT_DIR/2577"
+cp "$NAVIT_DIR/navit.exe" "$NAVIT_DIR/2577/autorun.exe"
+log "Created 2577/autorun.exe for SD card autorun"
 
 # --- Start Xvfb ---
 log "Starting Xvfb (rotate=$ROTATE)..."
@@ -92,10 +94,12 @@ log "Wine initialized"
 ROM_WIN="$(winepath -w "$(realpath "$EMU_DIR/rom.bin")")"
 SHARE_WIN="$(winepath -w "$(realpath "$NAVIT_DIR")")"
 
-# --- Launch Device Emulator ---
-log "Launching Device Emulator..."
+# --- Launch Device Emulator (without shared folder) ---
+# Boot without /sharedfolder so we can hot-plug it later via the Configure
+# dialog, triggering a genuine SD card insertion event for autorun.exe.
+log "Launching Device Emulator (no shared folder)..."
 
-EMU_ARGS=("$ROM_WIN" /memsize 128 /sharedfolder "$SHARE_WIN")
+EMU_ARGS=("$ROM_WIN" /memsize 128)
 if [ "$ROTATE" = "1" ] || [ "$ROTATE" = "3" ]; then
     EMU_ARGS+=(/video 320x240x16)
 fi
@@ -124,8 +128,8 @@ for i in $(seq 1 30); do
     sleep 2
 done
 
-# --- Let WM finish booting + autorun.exe to launch Navit ---
-log "Waiting 30s for WM to boot and autorun.exe to launch Navit..."
+# --- Wait for WinCE shell to fully boot ---
+log "Waiting 30s for WinCE shell to boot..."
 sleep 30
 capture_screenshot "01-post-boot"
 
@@ -134,7 +138,53 @@ if ! kill -0 "$EMU_PID" 2>/dev/null; then
     exit 1
 fi
 
-capture_screenshot "02-navit-check"
+# --- Hot-plug shared folder via File > Configure dialog ---
+# This simulates inserting an SD card after boot, which triggers
+# SHGetAutoRunPath() -> \Storage Card\2577\autorun.exe -> navit.exe
+log "Hot-plugging shared folder via File > Configure..."
+EMU_WID="$(xdotool search --name 'Device Emulator' 2>/dev/null | head -1 || true)"
+if [ -z "$EMU_WID" ]; then
+    log "WARNING: Could not find Device Emulator window for hot-plug"
+else
+    # Focus the emulator window and open File > Configure
+    xdotool windowactivate --sync "$EMU_WID"
+    sleep 1
+    xdotool key alt+f
+    sleep 1
+    capture_screenshot "02-file-menu"
+
+    # Click "Configure..." menu item (send 'c' key as accelerator)
+    xdotool key c
+    sleep 2
+    capture_screenshot "03-configure-dialog"
+
+    # The General tab should be active by default.
+    # The Shared folder field is the last text input on the General tab.
+    # Tab through the dialog fields to reach it, then type the path.
+    # Fields: ROM image, ROM address, RAM size, Flash file, Host key, FuncKey, Shared folder
+    for i in $(seq 1 12); do
+        xdotool key Tab
+        sleep 0.2
+    done
+    sleep 0.5
+
+    # Type the Windows path to the shared folder
+    xdotool type --delay 50 "$SHARE_WIN"
+    sleep 1
+    capture_screenshot "04-shared-folder-set"
+
+    # Press Enter to confirm (OK button)
+    xdotool key Return
+    sleep 2
+    capture_screenshot "05-after-hotplug"
+
+    log "Shared folder hot-plug attempted: $SHARE_WIN"
+fi
+
+# --- Wait for autorun to trigger ---
+log "Waiting 15s for autorun.exe to launch Navit..."
+sleep 15
+capture_screenshot "06-navit-check"
 
 # --- Monitor for remaining time ---
 REMAINING=$((SMOKE_TIMEOUT - (SECONDS - START)))

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -185,7 +185,6 @@ fi
 if [ "$ROTATE" = "1" ] || [ "$ROTATE" = "3" ]; then
     # --- LANDSCAPE MODE (320x240) ---
     # WM screen is 320w x 240h. Title bar at top, softkeys at bottom.
-    # Start button at top-left. Coordinates are estimated for first run.
 
     # Step 1: Tap "Start"
     log "Step 1: Tapping Start..."
@@ -193,29 +192,29 @@ if [ "$ROTATE" = "1" ] || [ "$ROTATE" = "3" ]; then
     sleep 3
     capture_screenshot "02-start-tapped"
 
-    # Step 2: Tap "Programs" — menu is taller than screen, Programs near bottom
-    # In landscape the start menu shows fewer items before scrolling.
-    # Items are same height (~18px) but menu may need scrolling.
+    # Step 2: Tap "Programs" (verified from landscape screenshot)
     log "Step 2: Tapping Programs..."
-    emu_click 50 170
+    emu_click 50 150
     sleep 3
     capture_screenshot "03-programs-tapped"
 
     # Step 3: Double-tap File Explorer in Programs grid
-    # Landscape grid may have more columns or same layout shifted.
-    # File Explorer: Row 2, Col 1 — estimate same relative position.
+    # Landscape grid is 4 columns x 3 rows (verified from screenshot):
+    #   Row 1 (y~65): Games(x~40), ActiveSync(x~115), Calculator(x~195), File Explorer(x~270)
+    #   Row 2 (y~140): Getting Started(x~40), Internet Sharing(x~115), Messenger(x~195), Notes(x~270)
+    #   Row 3 (y~210): Pictures&(x~40), Search(x~115), SimTkUI(x~195), Task(x~270)
     log "Step 3: Double-tapping File Explorer icon..."
-    emu_dblclick 40 145
+    emu_dblclick 270 65
     sleep 3
     capture_screenshot "04-after-file-explorer-dblclick"
 
     log "Step 3b: Trying File Explorer label area..."
-    emu_dblclick 40 165
+    emu_dblclick 270 80
     sleep 3
     capture_screenshot "05-after-label-dblclick"
 
     # Step 4: Navigate up to root
-    # Softkey bar: "Up" at bottom-left ~WM(40, 227)
+    # Softkey bar at bottom of 240px screen: "Up" at ~WM(40, 227)
     log "Step 4: Navigating up to root..."
     emu_click 40 227
     sleep 2
@@ -225,8 +224,7 @@ if [ "$ROTATE" = "1" ] || [ "$ROTATE" = "3" ]; then
     sleep 2
     capture_screenshot "06b-up2"
 
-    # Root listing — same item order, same ~18px row height
-    # In landscape the list area starts at ~y=37 (shorter title/address bar)
+    # Root listing — same items, ~18px rows starting at y≈37
     # Storage Card is 7th item: y ≈ 37 + 6*18 = 145
     log "Step 4b: Looking for Storage Card in root..."
     capture_screenshot "06c-root-view"
@@ -235,7 +233,7 @@ if [ "$ROTATE" = "1" ] || [ "$ROTATE" = "3" ]; then
     sleep 3
     capture_screenshot "06d-storage-card"
 
-    # Step 5: navit.exe is 4th item: y ≈ 37 + 3*18 = 91
+    # navit.exe is 4th item: y ≈ 37 + 3*18 = 91
     log "Step 5: Looking for navit.exe..."
     capture_screenshot "07-folder-contents"
 

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -206,74 +206,65 @@ emu_dblclick 40 165
 sleep 3
 capture_screenshot "05-after-label-dblclick"
 
-# Step 4: Navigate File Explorer to Storage Card
-# File Explorer shows \My Device root. Items in list view with ~20px rows.
-# Typical items: My Documents, Program Files, Storage Card, Temp, Windows
-# "Storage Card" is the shared folder from /sharedfolder flag.
-log "Step 4: Navigating to Storage Card..."
-capture_screenshot "06-current-view"
+# Step 4: Navigate up to root, then to Storage Card
+# File Explorer opened in "Templates" folder. Need to go up to My Device root.
+# Bottom softkey bar: "Up" at bottom-left ~WM(40, 307), "Menu" at bottom-right ~WM(200, 307)
+log "Step 4: Navigating up to root..."
 
-# Tap through the list looking for Storage Card
-# In File Explorer list, folders appear with folder icons, ~20px spacing
-# starting around y=35 below the address bar
-emu_click 120 55
-sleep 1
-capture_screenshot "06a-item1"
+# Tap "Up" to go from Templates -> My Documents
+emu_click 40 307
+sleep 2
+capture_screenshot "06a-up1"
 
-emu_click 120 75
-sleep 1
-capture_screenshot "06b-item2"
+# Tap "Up" again to go from My Documents -> My Device (root)
+emu_click 40 307
+sleep 2
+capture_screenshot "06b-up2"
 
-emu_click 120 95
-sleep 1
-capture_screenshot "06c-item3"
+# Now we should be at \My Device root.
+# Contents typically: My Documents, Program Files, Storage Card, Temp, Windows
+# Storage Card is the shared folder. Look for it in the list.
+# File Explorer list items: ~20px tall, starting around y=40
+log "Step 4b: Looking for Storage Card in root..."
+capture_screenshot "06c-root-view"
 
-emu_click 120 115
-sleep 1
-capture_screenshot "06d-item4"
+# Tap on items - Storage Card should be 3rd or 4th item
+# Items: My Documents(~y=40), Program Files(~y=60), Storage Card(~y=80)
+emu_click 120 80
+sleep 2
+capture_screenshot "06d-item-storage-card"
 
-emu_click 120 135
-sleep 1
-capture_screenshot "06e-item5"
+# If that was the wrong item, try the next ones
+emu_click 120 100
+sleep 2
+capture_screenshot "06e-item4"
 
-emu_click 120 155
-sleep 1
-capture_screenshot "06f-item6"
-
-emu_click 120 175
-sleep 1
-capture_screenshot "06g-item7"
+emu_click 120 120
+sleep 2
+capture_screenshot "06f-item5"
 
 # Step 5: Find and tap navit.exe in Storage Card
-log "Step 5: Looking for navit.exe..."
-capture_screenshot "07-looking-for-navit"
-
 # The shared folder contains: espeak-data/, icons/, locale/, maps/,
 # navit.exe, navit.xml, navit_layout_*.xml
-# navit.exe should be after the folders alphabetically
-emu_click 120 55
-sleep 1
-capture_screenshot "07a-try1"
+# Folders come first alphabetically, then files:
+#   espeak-data/ (~y=40), icons/ (~y=60), locale/ (~y=80), maps/ (~y=100),
+#   navit.exe (~y=120), navit.xml (~y=140), navit_layout_*.xml (~y=160+)
+log "Step 5: Looking for navit.exe..."
+capture_screenshot "07-folder-contents"
 
-emu_click 120 75
-sleep 1
-capture_screenshot "07b-try2"
+# navit.exe should be around the 5th item (after 4 folders)
+emu_click 120 120
+sleep 2
+capture_screenshot "07a-click-navit-exe"
 
-emu_click 120 95
-sleep 1
-capture_screenshot "07c-try3"
+# Try adjacent positions in case the list ordering is different
+emu_click 120 100
+sleep 2
+capture_screenshot "07b-click-alt1"
 
-emu_click 120 115
-sleep 1
-capture_screenshot "07d-try4"
-
-emu_click 120 135
-sleep 1
-capture_screenshot "07e-try5"
-
-emu_click 120 155
-sleep 1
-capture_screenshot "07f-try6"
+emu_click 120 140
+sleep 2
+capture_screenshot "07c-click-alt2"
 
 # Give Navit time to start and render
 log "Waiting 15s for Navit to initialize..."

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -224,20 +224,23 @@ if [ "$ROTATE" = "1" ] || [ "$ROTATE" = "3" ]; then
     sleep 2
     capture_screenshot "06b-up2"
 
-    # Root listing — same items, ~18px rows starting at y≈37
-    # Storage Card is 7th item: y ≈ 37 + 6*18 = 145
+    # Root listing (verified from landscape screenshot):
+    #   Items ~18px tall, starting at y≈50:
+    #   Application Data y≈50, ConnMgr y≈68, Documents and Settings y≈86,
+    #   MUSIC y≈104, My Documents y≈122, Program Files y≈140,
+    #   Storage Card y≈158, Temp y≈176, Windows y≈194
     log "Step 4b: Looking for Storage Card in root..."
     capture_screenshot "06c-root-view"
 
-    emu_click 160 145
+    emu_click 160 158
     sleep 3
     capture_screenshot "06d-storage-card"
 
-    # navit.exe is 4th item: y ≈ 37 + 3*18 = 91
+    # navit.exe is 4th item: y ≈ 50 + 3*18 = 104
     log "Step 5: Looking for navit.exe..."
     capture_screenshot "07-folder-contents"
 
-    emu_click 160 91
+    emu_click 160 104
     sleep 3
     capture_screenshot "07a-click-navit-exe"
 else

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -186,10 +186,22 @@ else
     import -window root "$RESULTS_DIR/04-submenu-hover-$(date '+%H%M%S').png" 2>/dev/null || true
     xdotool click 1
     sleep 2
-    import -window root "$RESULTS_DIR/05-after-reset-click-$(date '+%H%M%S').png" 2>/dev/null || true
-    log "Soft reset click attempted"
+    import -window root "$RESULTS_DIR/05-after-soft-click-$(date '+%H%M%S').png" 2>/dev/null || true
 
-    # Wait for the emulator to re-detect the window after reset
+    # A confirmation dialog appears: "Are you sure you want to reset the guest OS?"
+    # with Yes and No buttons. Click "Yes" to confirm.
+    CONFIRM_WID="$(xdotool search --name 'Device Emulator' 2>/dev/null | tail -1 || true)"
+    log "Confirmation dialog search result: $CONFIRM_WID"
+
+    # The "Yes" button is on the left side of the dialog, roughly centered.
+    # From screenshot: dialog is centered in the window, Yes at ~(130, 275)
+    # relative to emulator window. Just press Enter since Yes appears focused.
+    xdotool key --window "$CONFIRM_WID" Return
+    sleep 1
+    import -window root "$RESULTS_DIR/06-after-confirm-$(date '+%H%M%S').png" 2>/dev/null || true
+    log "Soft reset confirmed"
+
+    # Wait for the emulator to reboot
     sleep 5
     EMU_WID2="$(xdotool search --name 'Device Emulator' 2>/dev/null | head -1 || true)"
     if [ -n "$EMU_WID2" ]; then
@@ -202,7 +214,7 @@ fi
 # --- Wait for second boot + autorun ---
 log "Waiting 30s for WinCE to reboot and autorun.exe to launch Navit..."
 sleep 30
-capture_screenshot "06-post-reset"
+capture_screenshot "07-post-reset"
 
 # --- Monitor for remaining time ---
 REMAINING=$((SMOKE_TIMEOUT - (SECONDS - START)))

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -207,51 +207,74 @@ else
     sleep 2
     capture_screenshot "06-file-explorer-opened"
 
-    # Step 4: Navigate up from My Documents to My Device root
-    # File Explorer defaults to "My Documents". Use Backspace to go up.
-    log "Step 4: Going up to My Device root (Backspace)..."
-    emu_key BackSpace
-    sleep 1
-    capture_screenshot "07-my-device-root"
+    # Step 4: Navigate to Storage Card using the location dropdown
+    # File Explorer defaults to "My Documents". The location dropdown at the
+    # top shows "My Documents ▼". Tap on it to open the dropdown, then select
+    # "Storage Card".
+    #
+    # Also try F1 (left softkey = "Up" in File Explorer) to go up to root.
+    log "Step 4: Navigating to Storage Card..."
 
-    # Step 5: Navigate to Storage Card
-    # My Device root contains folders alphabetically:
-    #   My Documents, Network, Program Files, Storage Card, Temp, Windows
-    # Storage Card is typically the 4th item.
-    log "Step 5: Navigating to Storage Card..."
-    # First press Down to enter the file list, then navigate
-    for i in 1 2 3 4; do
-        emu_key Down
-    done
-    sleep 0.5
-    capture_screenshot "08-storage-card-highlighted"
+    # Method A: Press F1 (left softkey = "Up") to go up to My Device root
+    log "Step 4a: Pressing F1 (Up softkey)..."
+    emu_key F1
+    sleep 1
+    capture_screenshot "07-after-F1-up"
+
+    # Press F1 again in case we need another level up
+    emu_key F1
+    sleep 1
+    capture_screenshot "08-after-F1-up2"
+
+    # Method B: Tap on the location dropdown at the top of File Explorer
+    # The dropdown "My Documents ▼" (or "My Device ▼") is at the top.
+    # In landscape (320x240): dropdown at approximately guest (80, 25)
+    # In portrait (240x320): dropdown at approximately guest (60, 25)
+    log "Step 4b: Tapping location dropdown..."
+    if [ "$ROTATE" = "1" ] || [ "$ROTATE" = "3" ]; then
+        tap_guest 80 25 "location dropdown (landscape)"
+    else
+        tap_guest 60 25 "location dropdown (portrait)"
+    fi
+    sleep 1
+    capture_screenshot "09-location-dropdown"
+
+    # The dropdown should show a list including "Storage Card".
+    # Look for it and select it. Storage Card might be the last item.
+    # Try selecting "Storage Card" with Down arrows + Enter.
+    # Dropdown items might be: My Device, My Documents, Storage Card
+    # Navigate down to find Storage Card.
+    emu_key Down
+    emu_key Down
+    sleep 0.3
+    capture_screenshot "10-dropdown-nav"
     emu_key Return
     sleep 2
-    capture_screenshot "09-storage-card-contents"
+    capture_screenshot "11-storage-card-contents"
 
-    # Step 6: Find and open navit.exe
+    # Step 5: Find and open navit.exe
     # Storage Card contents (from navit-package):
     #   Folders first (alphabetical): 2577/, espeak-data/, icons/, locale/, maps/
     #   Then files: autorun.exe, navit.exe, navit.xml, navit_layout_*.xml, ...
     # navit.exe is the 7th item (5 folders + autorun.exe + navit.exe)
-    log "Step 6: Navigating to navit.exe..."
+    log "Step 5: Navigating to navit.exe..."
     for i in 1 2 3 4 5 6 7; do
         emu_key Down
     done
     sleep 0.5
-    capture_screenshot "10-navit-highlighted"
+    capture_screenshot "12-navit-highlighted"
     emu_key Return
     sleep 5
-    capture_screenshot "11-navit-launched"
+    capture_screenshot "13-navit-launched"
 
-    import -window root "$RESULTS_DIR/12-root-state-$(date '+%H%M%S').png" 2>/dev/null || true
+    import -window root "$RESULTS_DIR/14-root-state-$(date '+%H%M%S').png" 2>/dev/null || true
     log "GUI navigation complete"
 fi
 
 # --- Wait for Navit to potentially start ---
 log "Waiting 20s for Navit to initialize..."
 sleep 20
-capture_screenshot "13-after-wait"
+capture_screenshot "15-after-wait"
 
 # --- Monitor for remaining time ---
 REMAINING=$((SMOKE_TIMEOUT - (SECONDS - START)))

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -60,13 +60,13 @@ log "DeviceEmulator.exe: $(du -h "$EMU_DIR/DeviceEmulator.exe" | cut -f1)"
 log "rom.bin: $(du -h "$EMU_DIR/rom.bin" | cut -f1)"
 log "Navit package: $(find "$NAVIT_DIR" -type f | wc -l) files"
 
-# --- Auto-start: place navit.exe as autorun.exe on the Storage Card ---
-# WinCE auto-runs \Storage Card\2577\autorun.exe (2577 = ARM ARMV4I processor type)
-# when a storage card is detected. Also place in root as fallback.
-mkdir -p "$NAVIT_DIR/2577"
-cp "$NAVIT_DIR/navit.exe" "$NAVIT_DIR/2577/autorun.exe"
-cp "$NAVIT_DIR/navit.exe" "$NAVIT_DIR/autorun.exe"
-log "Created 2577/autorun.exe and autorun.exe"
+# --- Auto-start setup ---
+# WinCE executes all .exe files in \Storage Card\StartUp\ at end of boot.
+# Since /sharedfolder maps to \Storage Card, we create StartUp/navit.exe.
+mkdir -p "$NAVIT_DIR/StartUp"
+# Create a .lnk shortcut (WinCE text format: <charcount>#<command>)
+printf '27#\\Storage Card\\navit.exe' > "$NAVIT_DIR/StartUp/navit.lnk"
+log "Created StartUp/navit.lnk for auto-launch"
 
 # --- Start Xvfb ---
 log "Starting Xvfb (rotate=$ROTATE)..."

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -186,12 +186,19 @@ else
     capture_screenshot "04-programs-screen"
 
     # Step 3: Navigate to File Explorer in Programs grid
-    # Grid: Games(col1) → ActiveSync(col2) → Calculator(col3) → File Explorer(col4)
-    # 3 Right presses from default selection (Games).
-    log "Step 3: Navigating to File Explorer (3x Right)..."
-    emu_key Right
-    emu_key Right
-    emu_key Right
+    # Landscape grid (4 columns): Games | ActiveSync | Calculator | File Explorer
+    #   → 3 Right from Games
+    # Portrait grid (3 columns): Games | ActiveSync | Calculator
+    #                            File Explorer | Getting Started | ...
+    #   → 1 Down from Games (File Explorer is row 2, col 1)
+    log "Step 3: Navigating to File Explorer..."
+    if [ "$ROTATE" = "1" ] || [ "$ROTATE" = "3" ]; then
+        emu_key Right
+        emu_key Right
+        emu_key Right
+    else
+        emu_key Down
+    fi
     sleep 0.5
     capture_screenshot "05-file-explorer-highlighted"
     emu_key Return
@@ -225,20 +232,16 @@ else
     capture_screenshot "09-storage-card-contents"
 
     # Step 6: Navigate to navit.exe
-    # Storage Card (sorted, folders first):
-    #   1. 2577/        (folder)
-    #   2. espeak-data/ (folder)
-    #   3. icons/       (folder)
-    #   4. locale/      (folder)
-    #   5. maps/        (folder)
-    #   6. autorun.exe  (file)
-    #   7. navit.exe    (file) ← target (7 Down, or 6 if first item auto-selected)
-    log "Step 6: Navigating to navit.exe..."
-    for i in 1 2 3 4 5 6 7; do
-        emu_key Down
-    done
-    sleep 0.5
+    # Use type-ahead: pressing "n" in File Explorer jumps to the first
+    # file starting with "n" = navit.exe (7.93M, the largest "navit" file).
+    # Folders are listed first, then files alphabetically.
+    # autorun.exe comes before navit*, so "n" should jump to navit.exe.
+    log "Step 6: Jumping to navit.exe (type-ahead 'n')..."
+    xdotool type --window "$EMU_WID" "n"
+    sleep 1
     capture_screenshot "10-navit-highlighted"
+
+    # navit.exe should now be highlighted. Open it.
     emu_key Return
     sleep 5
     capture_screenshot "11-navit-launched"

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -9,19 +9,18 @@
 # Environment:
 #   EMU_DIR        - emulator directory (default: emulator)
 #   NAVIT_DIR      - navit package directory (default: navit-package)
-#   SMOKE_TIMEOUT  - total timeout in seconds (default: 120)
+#   SMOKE_TIMEOUT  - total timeout in seconds (default: 180)
 
 set -euo pipefail
 
 EMU_DIR="${EMU_DIR:-emulator}"
 NAVIT_DIR="${NAVIT_DIR:-navit-package}"
 RESULTS_DIR="smoke-results"
-SMOKE_TIMEOUT="${SMOKE_TIMEOUT:-120}"
+SMOKE_TIMEOUT="${SMOKE_TIMEOUT:-180}"
 
 export WINEPREFIX="$PWD/.wine-emu"
 export WINEARCH=win32
 export WINEDEBUG="-all,+err"
-# Skip mono/gecko downloads — they hang in CI and aren't needed for Device Emulator
 export WINEDLLOVERRIDES="mscoree=d;mshtml=d"
 
 mkdir -p "$RESULTS_DIR"
@@ -35,30 +34,35 @@ capture_screenshot() {
         log "Screenshot: $outfile" || true
 }
 
-# Click at coordinates relative to the emulator window
+# Click inside the WM screen area of the emulator.
+# The emulator window starts at screen position (3, 29) with a 19px Wine menu bar.
+# The WM screen area starts at screen (3, 48) and is 240x320 pixels.
+# WM coordinates (0,0) = screen (3, 48).
 emu_click() {
-    local x="$1" y="$2"
-    local win_id
-    win_id="$(xdotool search --name 'Device Emulator' 2>/dev/null | head -1 || \
-              xdotool search --name 'Pocket PC' 2>/dev/null | head -1 || true)"
-    if [ -n "$win_id" ]; then
-        # Get window geometry to find the offset
-        local wx wy
-        eval "$(xdotool getwindowgeometry --shell "$win_id" 2>/dev/null || true)"
-        wx="${X:-0}"
-        wy="${Y:-0}"
-        # The WM screen starts below the Wine menu bar (~20px)
-        # Coordinates are relative to the WM screen area
-        local abs_x=$((wx + x))
-        local abs_y=$((wy + 20 + y))
-        log "Click at WM($x,$y) -> screen($abs_x,$abs_y)"
-        xdotool mousemove "$abs_x" "$abs_y"
-        sleep 0.2
-        xdotool click 1
-        sleep 1
-    else
-        log "WARNING: Could not find emulator window for click"
-    fi
+    local wmx="$1" wmy="$2"
+    local sx=$((3 + wmx))
+    local sy=$((48 + wmy))
+    log "Click WM($wmx,$wmy) -> screen($sx,$sy)"
+    xdotool mousemove "$sx" "$sy"
+    sleep 0.3
+    xdotool mousedown 1
+    sleep 0.1
+    xdotool mouseup 1
+    sleep 1
+}
+
+# Double-click inside the WM screen area
+emu_dblclick() {
+    local wmx="$1" wmy="$2"
+    local sx=$((3 + wmx))
+    local sy=$((48 + wmy))
+    log "DblClick WM($wmx,$wmy) -> screen($sx,$sy)"
+    xdotool mousemove "$sx" "$sy"
+    sleep 0.2
+    xdotool mousedown 1; sleep 0.05; xdotool mouseup 1
+    sleep 0.15
+    xdotool mousedown 1; sleep 0.05; xdotool mouseup 1
+    sleep 1
 }
 
 cleanup() {
@@ -94,12 +98,11 @@ timeout 10 wineserver --wait 2>/dev/null || true
 log "Wine initialized"
 
 # --- Convert paths to Windows format ---
-EMU_WIN="$(winepath -w "$(realpath "$EMU_DIR/DeviceEmulator.exe")")"
 ROM_WIN="$(winepath -w "$(realpath "$EMU_DIR/rom.bin")")"
 SHARE_WIN="$(winepath -w "$(realpath "$NAVIT_DIR")")"
 
 # --- Launch Device Emulator ---
-log "Launching: wine $EMU_WIN $ROM_WIN /memsize 128 /sharedfolder $SHARE_WIN"
+log "Launching Device Emulator..."
 
 wine "$EMU_DIR/DeviceEmulator.exe" \
     "$ROM_WIN" \
@@ -110,108 +113,114 @@ EMU_PID=$!
 log "Device Emulator PID: $EMU_PID"
 
 # --- Wait for emulator window ---
-BOOT_TIMEOUT=60
-log "Waiting up to ${BOOT_TIMEOUT}s for emulator window..."
+log "Waiting for emulator window..."
 START=$SECONDS
-BOOTED=false
 
-while [ $((SECONDS - START)) -lt "$BOOT_TIMEOUT" ]; do
+for i in $(seq 1 30); do
     if ! kill -0 "$EMU_PID" 2>/dev/null; then
         log "Device Emulator died during boot"
         tail -30 "$RESULTS_DIR/wine-output.log" | tee -a "$RESULTS_DIR/smoke-test.log"
         capture_screenshot "crash"
         exit 1
     fi
-
-    if xdotool search --name "Device Emulator" 2>/dev/null | grep -q . || \
-       xdotool search --name "Pocket PC" 2>/dev/null | grep -q .; then
-        BOOTED=true
+    if xdotool search --name "Device Emulator" 2>/dev/null | grep -q .; then
         log "Emulator window detected after $((SECONDS - START))s"
         break
     fi
-
     sleep 2
 done
-
-if ! $BOOTED; then
-    if kill -0 "$EMU_PID" 2>/dev/null; then
-        log "WARNING: No window detected but process alive — continuing"
-    else
-        log "FATAL: No window and process dead"
-        capture_screenshot "crash"
-        exit 1
-    fi
-fi
 
 # --- Let WM finish booting ---
 log "Waiting 20s for WM to stabilize..."
 sleep 20
-capture_screenshot "post-boot"
+capture_screenshot "01-post-boot"
 
 if ! kill -0 "$EMU_PID" 2>/dev/null; then
     log "Device Emulator died after boot"
-    tail -30 "$RESULTS_DIR/wine-output.log" | tee -a "$RESULTS_DIR/smoke-test.log"
     exit 1
 fi
 
-# --- Launch Navit via xdotool clicks ---
-# The WM 6.1 Professional emulator has a 240x320 screen.
-# We need to navigate: Start > File Explorer > Storage Card > navit.exe
+# --- Navigate the WM UI to launch Navit ---
+# WM 6.1 Professional screen layout (240x320):
+#   Title bar: y=0-20  ("Start" text at ~x=30, y=8)
+#   Today screen content: y=20-295
+#   Softkey bar: y=295-320 ("Calendar" left, "Contacts" right)
 #
-# Coordinate reference (relative to WM screen area, 240x320):
-#   Start button: top-left area (~30, 7)
-#   Start menu items vary by position
-#
-# Alternative approach: use the emulator's File menu to run a command,
-# or navigate via File Explorer.
-#
-# Strategy: Click Start > Programs > File Explorer, then navigate to
-# Storage Card and tap navit.exe. Coordinates are approximate and may
-# need tuning based on actual menu layout.
+# Navigation plan:
+#   1. Tap Start (top bar)
+#   2. Tap Programs in the Start menu
+#   3. Tap File Explorer in the Programs list
+#   4. Navigate to Storage Card
+#   5. Tap navit.exe
 
-log "Attempting to launch Navit inside emulator..."
+log "=== Launching Navit via UI navigation ==="
 
-# Step 1: Click "Start" in the WM taskbar (top-left of WM screen)
-log "Step 1: Clicking Start..."
-emu_click 30 7
+# Focus the emulator window first
+WIN_ID="$(xdotool search --name 'Device Emulator' 2>/dev/null | head -1 || true)"
+if [ -n "$WIN_ID" ]; then
+    xdotool windowactivate "$WIN_ID" 2>/dev/null || true
+    xdotool windowfocus "$WIN_ID" 2>/dev/null || true
+    sleep 0.5
+fi
+
+# Step 1: Tap "Start" in WM title bar
+log "Step 1: Tapping Start..."
+emu_click 30 8
+sleep 3
+capture_screenshot "02-start-tapped"
+
+# Step 2: Tap "Programs" — in WM6 Start menu, Programs is near the bottom
+# The start menu shows recent apps at top, then Programs at bottom
+log "Step 2: Tapping Programs..."
+emu_click 120 270
+sleep 3
+capture_screenshot "03-programs-tapped"
+
+# Step 3: Tap "File Explorer" — it's in the Programs grid/list
+# File Explorer is typically in the first row of programs
+log "Step 3: Tapping File Explorer..."
+emu_click 60 100
+sleep 3
+capture_screenshot "04-file-explorer-tapped"
+
+# If we didn't get File Explorer, try scrolling or another position
+# File Explorer might be at a different spot
+log "Step 3b: Trying alternate File Explorer position..."
+emu_click 180 100
+sleep 3
+capture_screenshot "05-file-explorer-alt"
+
+# Step 4: Look for "Storage Card" in File Explorer
+# In File Explorer, folders are listed vertically
+log "Step 4: Tapping Storage Card..."
+emu_click 120 60
 sleep 2
-capture_screenshot "start-menu"
+capture_screenshot "06-storage-card"
 
-# Step 2: Click "Programs" in the Start menu
-# In WM6.1 Professional, "Programs" is typically near the bottom of the Start menu
-log "Step 2: Clicking Programs..."
-emu_click 120 280
+# Try tapping on first item in the list
+emu_click 120 100
 sleep 2
-capture_screenshot "programs-menu"
+capture_screenshot "07-folder-item"
 
-# Step 3: Look for File Explorer in Programs
-# File Explorer is typically in the Programs list
-log "Step 3: Clicking File Explorer..."
-emu_click 120 120
-sleep 2
-capture_screenshot "file-explorer"
+# Step 5: Look for navit.exe — try double-clicking first item
+log "Step 5: Launching navit.exe..."
+emu_dblclick 120 60
+sleep 3
+capture_screenshot "08-navit-attempt1"
 
-# Step 4: In File Explorer, look for "Storage Card" (the shared folder)
-log "Step 4: Looking for Storage Card..."
-emu_click 120 80
-sleep 2
-capture_screenshot "storage-card"
+emu_dblclick 120 100
+sleep 3
+capture_screenshot "09-navit-attempt2"
 
-# Step 5: Look for navit.exe
-log "Step 5: Looking for navit.exe..."
-emu_click 120 80
-sleep 2
-capture_screenshot "navit-click"
-
-# Give Navit time to start
-log "Waiting 10s for Navit to initialize..."
-sleep 10
-capture_screenshot "navit-startup"
+# Give Navit time to start and render
+log "Waiting 15s for Navit to initialize..."
+sleep 15
+capture_screenshot "10-navit-running"
 
 # --- Monitor for remaining time ---
 REMAINING=$((SMOKE_TIMEOUT - (SECONDS - START)))
 if [ "$REMAINING" -gt 0 ]; then
-    log "Monitoring for ${REMAINING}s more..."
+    log "Monitoring for ${REMAINING}s..."
     LAST_SHOT=$SECONDS
 
     while [ $((SECONDS - START)) -lt "$SMOKE_TIMEOUT" ]; do
@@ -231,7 +240,7 @@ if [ "$REMAINING" -gt 0 ]; then
 fi
 
 # --- Final ---
-capture_screenshot "final"
+capture_screenshot "99-final"
 
 if kill -0 "$EMU_PID" 2>/dev/null; then
     log "PASS: Device Emulator survived ${SMOKE_TIMEOUT}s"
@@ -240,7 +249,6 @@ else
     exit 1
 fi
 
-# Collect any Navit logs from the shared folder
 find "$NAVIT_DIR" -name "*.log" -exec cp {} "$RESULTS_DIR/" \; 2>/dev/null || true
 ps aux > "$RESULTS_DIR/processes.txt" 2>/dev/null || true
 

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -21,6 +21,8 @@ SMOKE_TIMEOUT="${SMOKE_TIMEOUT:-120}"
 export WINEPREFIX="$PWD/.wine-emu"
 export WINEARCH=win32
 export WINEDEBUG="-all,+err"
+# Skip mono/gecko downloads — they hang in CI and aren't needed for Device Emulator
+export WINEDLLOVERRIDES="mscoree=d;mshtml=d"
 
 mkdir -p "$RESULTS_DIR"
 
@@ -59,8 +61,12 @@ kill -0 "$XVFB_PID" 2>/dev/null || { log "FATAL: Xvfb failed to start"; exit 1; 
 
 # --- Initialize Wine ---
 log "Initializing Wine prefix..."
-wineboot --init 2>/dev/null
-wineserver --wait 2>/dev/null || true
+# Timeout wineboot — it can hang downloading mono/gecko even with WINEDLLOVERRIDES
+timeout 60 wineboot --init 2>/dev/null || {
+    log "WARNING: wineboot timed out or failed (exit $?) — continuing anyway"
+}
+timeout 10 wineserver --wait 2>/dev/null || true
+log "Wine initialized"
 
 # --- Convert paths to Windows format ---
 EMU_WIN="$(winepath -w "$(realpath "$EMU_DIR/DeviceEmulator.exe")")"

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -169,53 +169,100 @@ emu_click 30 8
 sleep 3
 capture_screenshot "02-start-tapped"
 
-# Step 2: Tap "Programs" — in WM6 Start menu, Programs is near the bottom
-# The start menu shows recent apps at top, then Programs at bottom
+# Step 2: Tap "Programs" in the Start menu
+# From screenshot analysis of the WM 6.1 Start menu layout:
+#   Today:            y~30
+#   Office Mobile:    y~50
+#   Calendar:         y~68
+#   Contacts:         y~86
+#   Internet Explorer:y~104
+#   Messaging:        y~122
+#   "Recent Programs":y~148
+#   Programs:         y~170
+#   Settings:         y~190
+#   Help:             y~208
 log "Step 2: Tapping Programs..."
-emu_click 120 270
+emu_click 50 170
 sleep 3
 capture_screenshot "03-programs-tapped"
 
-# Step 3: Tap "File Explorer" — it's in the Programs grid/list
-# File Explorer is typically in the first row of programs
-log "Step 3: Tapping File Explorer..."
-emu_click 60 100
-sleep 3
-capture_screenshot "04-file-explorer-tapped"
+# Step 3: In Programs view, find and tap File Explorer
+# Programs view shows icons in a grid. File Explorer is typically present.
+# The grid starts around y=35, icons are ~70px apart in rows
+# First try common positions in the Programs grid
+log "Step 3: Looking for File Explorer in Programs grid..."
+capture_screenshot "03b-programs-view"
 
-# If we didn't get File Explorer, try scrolling or another position
-# File Explorer might be at a different spot
-log "Step 3b: Trying alternate File Explorer position..."
-emu_click 180 100
-sleep 3
-capture_screenshot "05-file-explorer-alt"
+# Programs grid layout is typically 3 columns x N rows
+# Icons at approximately: col1=40, col2=120, col3=200, rows at y=50,110,170,230
+# File Explorer is usually in the first page. Try several positions.
+# We'll click each and check the result.
+emu_click 40 50
+sleep 2
+capture_screenshot "04a-programs-click1"
 
-# Step 4: Look for "Storage Card" in File Explorer
-# In File Explorer, folders are listed vertically
-log "Step 4: Tapping Storage Card..."
+# Check if we opened File Explorer or something else
+# If it's not File Explorer, go back and try next icon
+emu_click 120 50
+sleep 2
+capture_screenshot "04b-programs-click2"
+
+emu_click 200 50
+sleep 2
+capture_screenshot "04c-programs-click3"
+
+emu_click 40 110
+sleep 2
+capture_screenshot "04d-programs-click4"
+
+emu_click 120 110
+sleep 2
+capture_screenshot "04e-programs-click5"
+
+emu_click 200 110
+sleep 2
+capture_screenshot "04f-programs-click6"
+
+# Take a state screenshot
+capture_screenshot "05-after-grid-clicks"
+
+# If we've reached File Explorer, we should see a list of folders/files.
+# Look for "Storage Card" and tap it.
+# In File Explorer list view, items start around y=40 with ~20px spacing
+log "Step 4: Looking for Storage Card..."
+sleep 2
+
+# Try tapping items in the file list
+emu_click 120 40
+sleep 2
+capture_screenshot "06a-list-item1"
+
 emu_click 120 60
 sleep 2
-capture_screenshot "06-storage-card"
+capture_screenshot "06b-list-item2"
 
-# Try tapping on first item in the list
-emu_click 120 100
+emu_click 120 80
 sleep 2
-capture_screenshot "07-folder-item"
+capture_screenshot "06c-list-item3"
 
-# Step 5: Look for navit.exe — try double-clicking first item
-log "Step 5: Launching navit.exe..."
-emu_dblclick 120 60
-sleep 3
-capture_screenshot "08-navit-attempt1"
+# Step 5: If we're in a folder, look for navit.exe
+log "Step 5: Looking for navit.exe..."
+emu_click 120 40
+sleep 2
+capture_screenshot "07a-navit-try1"
 
-emu_dblclick 120 100
-sleep 3
-capture_screenshot "09-navit-attempt2"
+emu_click 120 60
+sleep 2
+capture_screenshot "07b-navit-try2"
+
+emu_click 120 80
+sleep 2
+capture_screenshot "07c-navit-try3"
 
 # Give Navit time to start and render
 log "Waiting 15s for Navit to initialize..."
 sleep 15
-capture_screenshot "10-navit-running"
+capture_screenshot "08-navit-running"
 
 # --- Monitor for remaining time ---
 REMAINING=$((SMOKE_TIMEOUT - (SECONDS - START)))

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -147,34 +147,47 @@ if [ -z "$EMU_WID" ]; then
     log "WARNING: Could not find Device Emulator window for hot-plug"
 else
     # Focus the emulator window and open File > Configure
-    xdotool windowactivate --sync "$EMU_WID"
+    xdotool windowfocus --sync "$EMU_WID" 2>/dev/null || true
+    xdotool windowraise "$EMU_WID" 2>/dev/null || true
     sleep 1
-    xdotool key alt+f
+    xdotool key --window "$EMU_WID" alt+f
     sleep 1
     capture_screenshot "02-file-menu"
 
     # Click "Configure..." menu item (send 'c' key as accelerator)
-    xdotool key c
+    xdotool key --window "$EMU_WID" c
     sleep 2
     capture_screenshot "03-configure-dialog"
+
+    # The Configure dialog should now be open. Find it.
+    CFG_WID="$(xdotool search --name 'Emulator Properties' 2>/dev/null | head -1 || true)"
+    if [ -z "$CFG_WID" ]; then
+        # Try alternative dialog title
+        CFG_WID="$(xdotool search --name 'Configure' 2>/dev/null | head -1 || true)"
+    fi
+    if [ -z "$CFG_WID" ]; then
+        log "WARNING: Configure dialog not found, falling back to emulator window"
+        CFG_WID="$EMU_WID"
+    fi
+    log "Configure dialog window: $CFG_WID"
 
     # The General tab should be active by default.
     # The Shared folder field is the last text input on the General tab.
     # Tab through the dialog fields to reach it, then type the path.
     # Fields: ROM image, ROM address, RAM size, Flash file, Host key, FuncKey, Shared folder
     for i in $(seq 1 12); do
-        xdotool key Tab
+        xdotool key --window "$CFG_WID" Tab
         sleep 0.2
     done
     sleep 0.5
 
     # Type the Windows path to the shared folder
-    xdotool type --delay 50 "$SHARE_WIN"
+    xdotool type --window "$CFG_WID" --delay 50 "$SHARE_WIN"
     sleep 1
     capture_screenshot "04-shared-folder-set"
 
     # Press Enter to confirm (OK button)
-    xdotool key Return
+    xdotool key --window "$CFG_WID" Return
     sleep 2
     capture_screenshot "05-after-hotplug"
 

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -51,6 +51,7 @@ emu_key() {
 }
 
 # Tap a point on the WinCE guest screen (guest coords).
+# The WinCE display starts below the host menu bar (~19px).
 MENU_BAR_H=19
 tap_guest() {
     local gx="$1" gy="$2" label="${3:-}"
@@ -145,26 +146,21 @@ if ! kill -0 "$EMU_PID" 2>/dev/null; then
 fi
 
 # --- Launch Navit via WinCE File Explorer ---
-# Navigate: Start > Programs > File Explorer > [up to root] > Storage Card > navit.exe
+# Navigate: Start > Programs > File Explorer > [root] > Storage Card > navit.exe
 #
-# Keyboard navigation:
-#   Super      → opens Start menu
-#   Down x6    → highlights "Programs"
-#   Return     → opens Programs screen
-#   Right x3   → highlights "File Explorer" (grid: row1 col4)
-#   Return     → opens File Explorer (defaults to My Documents)
-#   Backspace  → goes up to My Device root
-#   Down to "Storage Card" → Enter → navigate to navit.exe → Enter
+# Confirmed from CI screenshots:
 #
-# The Start menu layout (confirmed from landscape CI screenshots):
+# Start menu items (Super key opens it):
 #   Today, Office Mobile, Calendar, Contacts, Internet Explorer, Messaging,
-#   [Recent Programs header - not selectable],
-#   Programs, Settings, Help
+#   [Recent Programs header], Programs, Settings, Help
 #
-# Programs grid layout (4 columns, confirmed from CI screenshots):
+# Programs grid (4 columns):
 #   Row 1: Games | ActiveSync | Calculator | File Explorer
-#   Row 2: Getting Started | Internet Sharing | Messenger | Notes
-#   ...
+#
+# My Device root folders (F1 = Up from My Documents):
+#   Application Data, ConnMgr, Documents and Settings, MUSIC,
+#   My Documents, Program Files, Storage Card, Temp, Windows
+#   → Storage Card is the 7th item (6 Down from Application Data)
 log "Navigating WinCE GUI to launch navit.exe..."
 
 if [ -z "$EMU_WID" ]; then
@@ -173,108 +169,89 @@ else
     xdotool windowfocus "$EMU_WID" 2>/dev/null || true
     sleep 0.5
 
-    # Step 1: Open Start menu with Super (Windows) key
-    log "Step 1: Opening Start menu (Super key)..."
+    # Step 1: Open Start menu with Super key
+    log "Step 1: Opening Start menu..."
     emu_key super
     sleep 1
     capture_screenshot "02-start-menu"
 
-    # Step 2: Navigate to Programs (6x Down + Enter)
-    # From CI: Today is first, Programs is 7th selectable item (6 Down)
-    log "Step 2: Navigating to Programs (6x Down)..."
+    # Step 2: Tap "Programs" in the Start menu
+    # Use direct tap coordinates instead of arrow keys (more reliable).
+    # From CI screenshots:
+    #   Landscape (320x240): Programs at approx guest (70, 168)
+    #   Portrait (240x320): Programs at approx guest (70, 218)
+    log "Step 2: Tapping Programs..."
+    if [ "$ROTATE" = "1" ] || [ "$ROTATE" = "3" ]; then
+        tap_guest 70 168 "Programs (landscape)"
+    else
+        tap_guest 70 218 "Programs (portrait)"
+    fi
+    sleep 2
+    capture_screenshot "03-programs-screen"
+
+    # Step 3: Tap "File Explorer" in the Programs grid
+    # From CI screenshots: File Explorer is at row 1, col 4 (top-right area).
+    #   Landscape (320x240): File Explorer icon at approx guest (275, 55)
+    #   Portrait (240x320): File Explorer icon at approx guest (195, 55)
+    log "Step 3: Tapping File Explorer..."
+    if [ "$ROTATE" = "1" ] || [ "$ROTATE" = "3" ]; then
+        tap_guest 275 55 "File Explorer (landscape)"
+    else
+        tap_guest 195 55 "File Explorer (portrait)"
+    fi
+    sleep 2
+    capture_screenshot "04-file-explorer"
+
+    # Step 4: Go up to My Device root with F1 (left softkey = "Up")
+    # File Explorer defaults to "My Documents".
+    # F1 = "Up" in File Explorer → goes to My Device root.
+    log "Step 4: Pressing F1 (Up) to reach My Device root..."
+    emu_key F1
+    sleep 1
+    capture_screenshot "05-my-device-root"
+
+    # Step 5: Navigate to Storage Card
+    # My Device root (from CI screenshot):
+    #   1. Application Data (selected by default)
+    #   2. ConnMgr
+    #   3. Documents and Settings
+    #   4. MUSIC
+    #   5. My Documents
+    #   6. Program Files
+    #   7. Storage Card  ← target (6 Down presses)
+    log "Step 5: Navigating to Storage Card (6x Down)..."
     for i in 1 2 3 4 5 6; do
         emu_key Down
     done
     sleep 0.5
-    capture_screenshot "03-programs-highlighted"
-
-    # Use Enter to open Programs.
-    # In PPC, the action button to open an item is typically Enter/Return.
-    log "Step 2b: Opening Programs (Enter)..."
+    capture_screenshot "06-storage-card-highlighted"
     emu_key Return
     sleep 2
-    capture_screenshot "04-programs-screen"
+    capture_screenshot "07-storage-card-contents"
 
-    # Step 3: Navigate to File Explorer (3x Right + Enter)
-    # Grid: Games(col1) → ActiveSync(col2) → Calculator(col3) → File Explorer(col4)
-    log "Step 3: Navigating to File Explorer (3x Right)..."
-    emu_key Right
-    emu_key Right
-    emu_key Right
-    sleep 0.5
-    capture_screenshot "05-file-explorer-highlighted"
-    emu_key Return
-    sleep 2
-    capture_screenshot "06-file-explorer-opened"
-
-    # Step 4: Navigate to Storage Card using the location dropdown
-    # File Explorer defaults to "My Documents". The location dropdown at the
-    # top shows "My Documents ▼". Tap on it to open the dropdown, then select
-    # "Storage Card".
-    #
-    # Also try F1 (left softkey = "Up" in File Explorer) to go up to root.
-    log "Step 4: Navigating to Storage Card..."
-
-    # Method A: Press F1 (left softkey = "Up") to go up to My Device root
-    log "Step 4a: Pressing F1 (Up softkey)..."
-    emu_key F1
-    sleep 1
-    capture_screenshot "07-after-F1-up"
-
-    # Press F1 again in case we need another level up
-    emu_key F1
-    sleep 1
-    capture_screenshot "08-after-F1-up2"
-
-    # Method B: Tap on the location dropdown at the top of File Explorer
-    # The dropdown "My Documents ▼" (or "My Device ▼") is at the top.
-    # In landscape (320x240): dropdown at approximately guest (80, 25)
-    # In portrait (240x320): dropdown at approximately guest (60, 25)
-    log "Step 4b: Tapping location dropdown..."
-    if [ "$ROTATE" = "1" ] || [ "$ROTATE" = "3" ]; then
-        tap_guest 80 25 "location dropdown (landscape)"
-    else
-        tap_guest 60 25 "location dropdown (portrait)"
-    fi
-    sleep 1
-    capture_screenshot "09-location-dropdown"
-
-    # The dropdown should show a list including "Storage Card".
-    # Look for it and select it. Storage Card might be the last item.
-    # Try selecting "Storage Card" with Down arrows + Enter.
-    # Dropdown items might be: My Device, My Documents, Storage Card
-    # Navigate down to find Storage Card.
-    emu_key Down
-    emu_key Down
-    sleep 0.3
-    capture_screenshot "10-dropdown-nav"
-    emu_key Return
-    sleep 2
-    capture_screenshot "11-storage-card-contents"
-
-    # Step 5: Find and open navit.exe
-    # Storage Card contents (from navit-package):
-    #   Folders first (alphabetical): 2577/, espeak-data/, icons/, locale/, maps/
-    #   Then files: autorun.exe, navit.exe, navit.xml, navit_layout_*.xml, ...
+    # Step 6: Navigate to navit.exe
+    # Storage Card contents (sorted alphabetically, folders first):
+    #   Folders: 2577, espeak-data, icons, locale, maps (5 folders)
+    #   Files: autorun.exe, navit.exe, navit.xml, navit_layout_*.xml, ...
     # navit.exe is the 7th item (5 folders + autorun.exe + navit.exe)
-    log "Step 5: Navigating to navit.exe..."
+    log "Step 6: Navigating to navit.exe (7x Down)..."
     for i in 1 2 3 4 5 6 7; do
         emu_key Down
     done
     sleep 0.5
-    capture_screenshot "12-navit-highlighted"
+    capture_screenshot "08-navit-highlighted"
     emu_key Return
     sleep 5
-    capture_screenshot "13-navit-launched"
+    capture_screenshot "09-navit-launched"
 
-    import -window root "$RESULTS_DIR/14-root-state-$(date '+%H%M%S').png" 2>/dev/null || true
+    import -window root "$RESULTS_DIR/10-root-state-$(date '+%H%M%S').png" 2>/dev/null || true
     log "GUI navigation complete"
 fi
 
 # --- Wait for Navit to potentially start ---
 log "Waiting 20s for Navit to initialize..."
 sleep 20
-capture_screenshot "15-after-wait"
+capture_screenshot "11-after-wait"
 
 # --- Monitor for remaining time ---
 REMAINING=$((SMOKE_TIMEOUT - (SECONDS - START)))

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -120,10 +120,14 @@ SHARE_WIN="$(winepath -w "$(realpath "$NAVIT_DIR")")"
 # --- Launch Device Emulator ---
 log "Launching Device Emulator..."
 
+EMU_ARGS=("$ROM_WIN" /memsize 128 /sharedfolder "$SHARE_WIN")
+if [ "$ROTATE" = "1" ] || [ "$ROTATE" = "3" ]; then
+    # Override video mode for landscape (320x240 instead of default 240x320)
+    EMU_ARGS+=(/video 320x240x16)
+fi
+
 wine "$EMU_DIR/DeviceEmulator.exe" \
-    "$ROM_WIN" \
-    /memsize 128 \
-    /sharedfolder "$SHARE_WIN" \
+    "${EMU_ARGS[@]}" \
     > "$RESULTS_DIR/wine-output.log" 2>&1 &
 EMU_PID=$!
 log "Device Emulator PID: $EMU_PID"
@@ -174,36 +178,7 @@ if [ -n "$WIN_ID" ]; then
     sleep 0.5
 fi
 
-# Rotate screen if requested. Device Emulator doesn't support /rotate CLI flag.
-# Keyboard goes to WM guest, so use click-drag on Wine menu bar instead.
-# Click Flash, hold, drag to dropdown item, release.
 if [ "$ROTATE" != "0" ]; then
-    log "Rotating screen $ROTATE x 90 degrees via Flash menu..."
-    for i in $(seq 1 "$ROTATE"); do
-        # Press-and-hold on "Flash" in Wine menu bar, drag to dropdown item
-        xdotool mousemove --window "$WIN_ID" 50 12
-        sleep 0.2
-        xdotool mousedown 1
-        sleep 0.5
-        capture_screenshot "00-flash-held-$i"
-        # Drag down to first dropdown item
-        xdotool mousemove --window "$WIN_ID" 50 28
-        sleep 0.5
-        capture_screenshot "00-flash-drag1-$i"
-        # Try second item
-        xdotool mousemove --window "$WIN_ID" 50 42
-        sleep 0.5
-        capture_screenshot "00-flash-drag2-$i"
-        # Try third item
-        xdotool mousemove --window "$WIN_ID" 50 56
-        sleep 0.5
-        capture_screenshot "00-flash-drag3-$i"
-        # Release on whichever item we're on - we'll check screenshots
-        xdotool mouseup 1
-        sleep 2
-        capture_screenshot "00-rotate-result-$i"
-    done
-    sleep 3
     capture_screenshot "00-after-rotate"
 fi
 

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# WinCE Smoke Test: Boot Device Emulator under Wine+Xvfb, auto-launch Navit, verify startup.
+# WinCE Smoke Test: Boot Device Emulator under Wine+Xvfb, launch Navit, verify startup.
 #
 # Expects:
 #   emulator/DeviceEmulator.exe  — from wince-setup-emulator.sh
@@ -44,6 +44,20 @@ capture_screenshot() {
     fi
 }
 
+# Tap a point on the WinCE guest screen.
+# Guest coordinates are relative to the WinCE display area,
+# which starts below the host menu bar (~19px).
+MENU_BAR_H=19
+tap_guest() {
+    local gx="$1" gy="$2" label="${3:-}"
+    local wx=$gx
+    local wy=$((gy + MENU_BAR_H))
+    [ -n "$label" ] && log "Tap ($gx,$gy) [${label}]"
+    xdotool mousemove --window "$EMU_WID" "$wx" "$wy"
+    sleep 0.3
+    xdotool click --window "$EMU_WID" 1
+}
+
 cleanup() {
     log "Cleaning up..."
     [ -n "${EMU_PID:-}" ] && kill "$EMU_PID" 2>/dev/null && sleep 1 && kill -9 "$EMU_PID" 2>/dev/null || true
@@ -59,16 +73,6 @@ trap cleanup EXIT
 log "DeviceEmulator.exe: $(du -h "$EMU_DIR/DeviceEmulator.exe" | cut -f1)"
 log "rom.bin: $(du -h "$EMU_DIR/rom.bin" | cut -f1)"
 log "Navit package: $(find "$NAVIT_DIR" -type f | wc -l) files"
-
-# --- Auto-start setup ---
-# Place autorun.exe in the ARM processor-specific subfolder (2577 = ARMV4I).
-# WinCE shell calls SHGetAutoRunPath() when a storage card is INSERTED and
-# runs \Storage Card\<procID>\autorun.exe automatically.
-# We also place a copy at the root for ROMs that check there instead.
-mkdir -p "$NAVIT_DIR/2577"
-cp "$NAVIT_DIR/navit.exe" "$NAVIT_DIR/2577/autorun.exe"
-cp "$NAVIT_DIR/navit.exe" "$NAVIT_DIR/autorun.exe"
-log "Created autorun.exe at root and 2577/ for SD card autorun"
 
 # --- Start Xvfb ---
 log "Starting Xvfb (rotate=$ROTATE)..."
@@ -95,12 +99,9 @@ ROM_WIN="$(winepath -w "$(realpath "$EMU_DIR/rom.bin")")"
 SHARE_WIN="$(winepath -w "$(realpath "$NAVIT_DIR")")"
 
 # --- Launch Device Emulator ---
-# Boot WITHOUT /sharedfolder so we can hot-plug it later.
-# Hot-plugging triggers a genuine storage card insertion event in WinCE,
-# which causes the shell to detect and run autorun.exe.
-log "Launching Device Emulator (without shared folder)..."
+log "Launching Device Emulator..."
 
-EMU_ARGS=("$ROM_WIN" /memsize 128)
+EMU_ARGS=("$ROM_WIN" /memsize 128 /sharedfolder "$SHARE_WIN")
 if [ "$ROTATE" = "1" ] || [ "$ROTATE" = "3" ]; then
     EMU_ARGS+=(/video 320x240x16)
 fi
@@ -129,6 +130,8 @@ for i in $(seq 1 30); do
     sleep 2
 done
 
+EMU_WID="$(xdotool search --name 'Device Emulator' 2>/dev/null | head -1 || true)"
+
 # --- Wait for WinCE shell to fully boot ---
 log "Waiting 30s for WinCE shell to boot..."
 sleep 30
@@ -139,129 +142,80 @@ if ! kill -0 "$EMU_PID" 2>/dev/null; then
     exit 1
 fi
 
-# --- Hot-plug storage card via File > Configure ---
-# Open the Device Emulator's Configure dialog and set the shared folder.
-# This triggers a genuine storage card insertion event in WinCE,
-# which causes the shell to execute autorun.exe → launches Navit.
-log "Hot-plugging storage card via File > Configure..."
-EMU_WID="$(xdotool search --name 'Device Emulator' 2>/dev/null | head -1 || true)"
+# --- Launch Navit via WinCE File Explorer ---
+# Navigate the WinCE GUI: Start > Programs > File Explorer > Storage Card > navit.exe
+# All coordinates are in WinCE guest screen space (240x320 portrait, 320x240 landscape).
+log "Navigating WinCE GUI to launch navit.exe..."
+
 if [ -z "$EMU_WID" ]; then
-    log "WARNING: Could not find Device Emulator window for hot-plug"
+    log "WARNING: Could not find Device Emulator window"
 else
     xdotool windowfocus "$EMU_WID" 2>/dev/null || true
     sleep 0.5
 
-    # Get window geometry for menu coordinate calculation
-    eval "$(xdotool getwindowgeometry --shell "$EMU_WID" 2>/dev/null)" || true
-    log "Emulator window at X=$X Y=$Y W=${WIDTH:-?} H=${HEIGHT:-?}"
-
-    # Click "File" in the host menu bar
-    xdotool mousemove --window "$EMU_WID" 15 8
-    sleep 0.3
-    xdotool click --window "$EMU_WID" 1
+    # Dismiss any "Device unlocked" notification by tapping the main area
+    tap_guest 120 160 "dismiss notifications"
     sleep 1
-    import -window root "$RESULTS_DIR/02-file-menu-$(date '+%H%M%S').png" 2>/dev/null || true
 
-    # Click "Configure..." (4th item in File dropdown)
-    #   Save State and Exit  (~18px)
-    #   Clear Saved State    (~18px)
-    #   Reset >              (~18px)
-    #   Configure...         (~18px)  <-- target
-    #   Exit
-    CONF_X=$((X + 50))
-    CONF_Y=$((Y + 19 + 18*3 + 9))
-    log "Clicking Configure at absolute ($CONF_X, $CONF_Y)"
-    xdotool mousemove "$CONF_X" "$CONF_Y"
-    sleep 0.5
-    import -window root "$RESULTS_DIR/03-configure-hover-$(date '+%H%M%S').png" 2>/dev/null || true
-    xdotool click 1
+    # Step 1: Tap "Start" at top-left of WinCE screen
+    # The Start button in PPC 2003 SE is in the top-left corner with a flag icon.
+    tap_guest 25 12 "Start button"
     sleep 2
-    import -window root "$RESULTS_DIR/04-configure-dialog-$(date '+%H%M%S').png" 2>/dev/null || true
+    capture_screenshot "02-start-menu"
 
-    # The Configure dialog should now be open.
-    # We need to find and fill the "Shared Folder" field.
-    # Look for the Configure dialog window.
-    CONF_WID="$(xdotool search --name 'Emulator Properties' 2>/dev/null | head -1 || true)"
-    if [ -z "$CONF_WID" ]; then
-        CONF_WID="$(xdotool search --name 'Configure' 2>/dev/null | head -1 || true)"
-    fi
-    if [ -z "$CONF_WID" ]; then
-        CONF_WID="$(xdotool getactivewindow 2>/dev/null || true)"
-    fi
-    log "Configure dialog window: ${CONF_WID:-not found}"
+    # Step 2: Tap "Programs" in the Start menu
+    # In PPC 2003 SE, the Start menu shows items vertically.
+    # "Programs" is typically near the bottom with a folder icon.
+    # The start menu occupies roughly the top 2/3 of the screen.
+    # Common items: Today, Calendar, Contacts, IE, Messaging, etc.
+    # Programs is usually the 7th-9th item.
+    # Each item is ~26px tall. Programs at roughly y=26*8+26 = 234
+    # But there's also a title area. Let's estimate y=260.
+    tap_guest 100 260 "Programs"
+    sleep 2
+    capture_screenshot "03-programs"
 
-    if [ -n "$CONF_WID" ]; then
-        # Take a screenshot of the dialog window itself
-        import -window "$CONF_WID" "$RESULTS_DIR/05-configure-window-$(date '+%H%M%S').png" 2>/dev/null || true
+    # Step 3: Tap "File Explorer" in the Programs screen
+    # The Programs screen shows icons in a grid layout.
+    # File Explorer typically has a folder icon with a magnifying glass.
+    # Icons are arranged in rows of ~4, with ~60px spacing.
+    # File Explorer is often in the first or second row.
+    # Let's try a few common positions.
+    # Row 1: y ≈ 55, icons at x ≈ 30, 90, 150, 210
+    # Row 2: y ≈ 115, icons at x ≈ 30, 90, 150, 210
+    tap_guest 40 55 "File Explorer (guess: row1, col1)"
+    sleep 2
+    capture_screenshot "04-after-programs-tap"
 
-        # Try to find the shared folder field.
-        # In the Device Emulator Properties dialog, there's typically a
-        # "Shared Folder" text field. Try using Tab to navigate to it.
-        # The dialog may have multiple tabs and fields.
-        # Strategy: use xdotool to type the shared folder path into the
-        # field. We'll try Alt+keyboard shortcuts first.
+    # Step 4: Look for Storage Card in File Explorer
+    # File Explorer shows a list of folders/files in My Device.
+    # Storage Card should be one of the items.
+    # The file list starts below the address bar (~40px from top).
+    # Items are ~20px tall in list view.
+    # Common items: My Documents, Program Files, Storage Card, Windows, etc.
+    # Storage Card might be the 3rd-5th item.
+    tap_guest 100 120 "Storage Card (guess)"
+    sleep 2
+    capture_screenshot "05-storage-card"
 
-        # First, let's see if there's a "General" or "Peripherals" tab
-        # with the shared folder. Take a screenshot of the dialog first.
-        xdotool windowfocus "$CONF_WID" 2>/dev/null || true
-        sleep 0.5
+    # Step 5: Find and tap navit.exe
+    # In Storage Card, navit.exe should be in the file list.
+    # But there are many files. It might be alphabetically sorted.
+    # navit.exe would be near the middle of an alphabetical list.
+    # Let's try tapping on the first visible .exe file.
+    tap_guest 100 80 "navit.exe (guess)"
+    sleep 3
+    capture_screenshot "06-navit-attempt"
 
-        # Try clicking on "General" tab if it exists (usually first tab, top-left)
-        # Tab headers are typically at the top of the dialog
-        # Try clicking at various positions to find the shared folder field
-
-        # Get configure dialog geometry
-        eval "$(xdotool getwindowgeometry --shell "$CONF_WID" 2>/dev/null)" || {
-            log "Could not get Configure dialog geometry"
-        }
-        log "Configure dialog at X=$X Y=$Y W=${WIDTH:-?} H=${HEIGHT:-?}"
-
-        # The shared folder field is likely a text input near the bottom of
-        # the General tab. Try clearing any existing value and typing our path.
-        # Use Ctrl+A to select all text in a field, then type the new path.
-
-        # Navigate through the dialog controls with Tab
-        # Try tabbing through and typing at each position,
-        # taking screenshots to see where we are
-        for tab_count in 1 2 3 4 5 6 7 8; do
-            xdotool key Tab
-            sleep 0.2
-        done
-        import -window root "$RESULTS_DIR/06-after-tabs-$(date '+%H%M%S').png" 2>/dev/null || true
-
-        # Try typing the shared folder path
-        # First select all text in the current field
-        xdotool key ctrl+a
-        sleep 0.2
-        xdotool type --clearmodifiers "$SHARE_WIN"
-        sleep 0.5
-        import -window root "$RESULTS_DIR/07-after-type-$(date '+%H%M%S').png" 2>/dev/null || true
-
-        # Click OK to apply (typically bottom-right of dialog)
-        # OK button is usually at the bottom of the dialog
-        if [ -n "${WIDTH:-}" ] && [ -n "${HEIGHT:-}" ]; then
-            OK_X=$((X + WIDTH - 170))
-            OK_Y=$((Y + HEIGHT - 15))
-            log "Clicking OK at absolute ($OK_X, $OK_Y)"
-            xdotool mousemove "$OK_X" "$OK_Y"
-            sleep 0.3
-            xdotool click 1
-        else
-            # Fallback: press Enter for OK
-            xdotool key Return
-        fi
-        sleep 2
-        import -window root "$RESULTS_DIR/08-after-ok-$(date '+%H%M%S').png" 2>/dev/null || true
-        log "Configure dialog closed"
-    else
-        log "WARNING: Could not find Configure dialog window"
-    fi
+    # Take a root screenshot to see the full state
+    import -window root "$RESULTS_DIR/07-root-state-$(date '+%H%M%S').png" 2>/dev/null || true
+    log "GUI navigation complete"
 fi
 
-# --- Wait for Navit to launch via autorun ---
-log "Waiting 30s for autorun.exe to detect storage card and launch Navit..."
-sleep 30
-capture_screenshot "09-post-hotplug"
+# --- Wait for Navit to potentially start ---
+log "Waiting 20s for Navit to initialize..."
+sleep 20
+capture_screenshot "08-after-wait"
 
 # --- Monitor for remaining time ---
 REMAINING=$((SMOKE_TIMEOUT - (SECONDS - START)))

--- a/scripts/ci/wince-smoke-test.sh
+++ b/scripts/ci/wince-smoke-test.sh
@@ -44,6 +44,12 @@ capture_screenshot() {
     fi
 }
 
+# Send a key to the emulator window
+emu_key() {
+    xdotool key --window "$EMU_WID" "$1"
+    sleep 0.3
+}
+
 # Tap a point on the WinCE guest screen.
 # Guest coordinates are relative to the WinCE display area,
 # which starts below the host menu bar (~19px).
@@ -143,8 +149,9 @@ if ! kill -0 "$EMU_PID" 2>/dev/null; then
 fi
 
 # --- Launch Navit via WinCE File Explorer ---
-# Navigate the WinCE GUI: Start > Programs > File Explorer > Storage Card > navit.exe
-# All coordinates are in WinCE guest screen space (240x320 portrait, 320x240 landscape).
+# Navigate: Start > Programs > File Explorer > Storage Card > navit.exe
+# Use keyboard navigation (arrow keys + Enter) which works regardless of
+# screen orientation, instead of fragile pixel-coordinate tapping.
 log "Navigating WinCE GUI to launch navit.exe..."
 
 if [ -z "$EMU_WID" ]; then
@@ -153,69 +160,108 @@ else
     xdotool windowfocus "$EMU_WID" 2>/dev/null || true
     sleep 0.5
 
-    # Dismiss any "Device unlocked" notification by tapping the main area
-    tap_guest 120 160 "dismiss notifications"
+    # Step 1: Open Start menu
+    # Try multiple approaches: F1 (left softkey = Start in PPC),
+    # Windows/Super key, and direct tap on Start button.
+    log "Step 1: Opening Start menu..."
+
+    # Try F1 first (left softkey, which is "Start" on Today screen)
+    emu_key F1
     sleep 1
+    capture_screenshot "02-after-F1"
 
-    # Step 1: Tap "Start" at top-left of WinCE screen
-    # The Start button in PPC 2003 SE is in the top-left corner with a flag icon.
-    tap_guest 25 12 "Start button"
+    # Also try tapping the Start button area at the top-left
+    # The WinCE nav bar "Start" is at approximately guest (15, 5)
+    tap_guest 15 5 "Start button tap"
+    sleep 1
+    capture_screenshot "03-after-start-tap"
+
+    # Try Windows/Super key as another approach
+    emu_key super
+    sleep 1
+    capture_screenshot "04-after-super"
+
+    # Step 2: Navigate to Programs using keyboard
+    # PPC Start menu items (from landscape screenshot):
+    #   1. Today (selected by default)
+    #   2. Office Mobile
+    #   3. Calendar
+    #   4. Contacts
+    #   5. Internet Explorer
+    #   6. Messaging
+    #   7. Programs  <-- target (6 Down presses from Today)
+    log "Step 2: Navigating to Programs..."
+    for i in 1 2 3 4 5 6; do
+        emu_key Down
+    done
+    sleep 0.5
+    capture_screenshot "05-programs-highlight"
+
+    # Press Enter to open Programs
+    emu_key Return
     sleep 2
-    capture_screenshot "02-start-menu"
+    capture_screenshot "06-programs-screen"
 
-    # Step 2: Tap "Programs" in the Start menu
-    # In PPC 2003 SE, the Start menu shows items vertically.
-    # "Programs" is typically near the bottom with a folder icon.
-    # The start menu occupies roughly the top 2/3 of the screen.
-    # Common items: Today, Calendar, Contacts, IE, Messaging, etc.
-    # Programs is usually the 7th-9th item.
-    # Each item is ~26px tall. Programs at roughly y=26*8+26 = 234
-    # But there's also a title area. Let's estimate y=260.
-    tap_guest 100 260 "Programs"
+    # Step 3: Find and open File Explorer in Programs screen
+    # Programs screen shows a grid of program icons.
+    # We need to navigate to File Explorer.
+    # In PPC 2003 SE, Programs typically shows:
+    #   Row 1: Games, Calculator, ...
+    #   File Explorer might be in the list view.
+    # Try keyboard navigation: Tab/arrows to find File Explorer.
+    # First, let's just take a screenshot and see what we have.
+    # Try pressing Down a few times to find File Explorer.
+    log "Step 3: Looking for File Explorer..."
+
+    # In the Programs screen, items may be in a grid.
+    # Try navigating with arrow keys.
+    for i in 1 2 3; do
+        emu_key Down
+    done
+    sleep 0.5
+    capture_screenshot "07-programs-nav"
+
+    # Try selecting the current item
+    emu_key Return
     sleep 2
-    capture_screenshot "03-programs"
+    capture_screenshot "08-after-programs-select"
 
-    # Step 3: Tap "File Explorer" in the Programs screen
-    # The Programs screen shows icons in a grid layout.
-    # File Explorer typically has a folder icon with a magnifying glass.
-    # Icons are arranged in rows of ~4, with ~60px spacing.
-    # File Explorer is often in the first or second row.
-    # Let's try a few common positions.
-    # Row 1: y ≈ 55, icons at x ≈ 30, 90, 150, 210
-    # Row 2: y ≈ 115, icons at x ≈ 30, 90, 150, 210
-    tap_guest 40 55 "File Explorer (guess: row1, col1)"
+    # Step 4: If we're in File Explorer, look for Storage Card
+    # If not, we need to adjust. Take screenshots to diagnose.
+    log "Step 4: Looking for Storage Card..."
+    # In File Explorer list view, navigate down to find Storage Card
+    for i in 1 2 3 4 5; do
+        emu_key Down
+    done
+    sleep 0.5
+    capture_screenshot "09-file-list"
+
+    # Open selected item
+    emu_key Return
     sleep 2
-    capture_screenshot "04-after-programs-tap"
+    capture_screenshot "10-after-open"
 
-    # Step 4: Look for Storage Card in File Explorer
-    # File Explorer shows a list of folders/files in My Device.
-    # Storage Card should be one of the items.
-    # The file list starts below the address bar (~40px from top).
-    # Items are ~20px tall in list view.
-    # Common items: My Documents, Program Files, Storage Card, Windows, etc.
-    # Storage Card might be the 3rd-5th item.
-    tap_guest 100 120 "Storage Card (guess)"
-    sleep 2
-    capture_screenshot "05-storage-card"
+    # Step 5: Look for navit.exe in Storage Card
+    log "Step 5: Looking for navit.exe..."
+    # Navigate through file list
+    for i in 1 2 3; do
+        emu_key Down
+    done
+    sleep 0.5
 
-    # Step 5: Find and tap navit.exe
-    # In Storage Card, navit.exe should be in the file list.
-    # But there are many files. It might be alphabetically sorted.
-    # navit.exe would be near the middle of an alphabetical list.
-    # Let's try tapping on the first visible .exe file.
-    tap_guest 100 80 "navit.exe (guess)"
+    # Open navit.exe
+    emu_key Return
     sleep 3
-    capture_screenshot "06-navit-attempt"
+    capture_screenshot "11-navit-attempt"
 
-    # Take a root screenshot to see the full state
-    import -window root "$RESULTS_DIR/07-root-state-$(date '+%H%M%S').png" 2>/dev/null || true
+    import -window root "$RESULTS_DIR/12-root-state-$(date '+%H%M%S').png" 2>/dev/null || true
     log "GUI navigation complete"
 fi
 
 # --- Wait for Navit to potentially start ---
 log "Waiting 20s for Navit to initialize..."
 sleep 20
-capture_screenshot "08-after-wait"
+capture_screenshot "13-after-wait"
 
 # --- Monitor for remaining time ---
 REMAINING=$((SMOKE_TIMEOUT - (SECONDS - START)))


### PR DESCRIPTION
## Summary
- Adds `smoke_test_wince` job to build.yml, runs after `build_wince`
- Downloads Microsoft Device Emulator 3.0 + WM 6.1 ROM from Internet Archive
- Boots emulator under Wine+Xvfb on GitHub-hosted Ubuntu runner
- Captures screenshots at boot, post-boot, and periodically
- Uploads all results as CI artifacts

## Test plan
- [ ] CI run passes the emulator setup step (downloads + extracts)
- [ ] Wine installs and initializes successfully
- [ ] Device Emulator boots under Wine+Xvfb
- [ ] Screenshots captured and uploaded as artifacts
- [ ] Emulator survives the full 120s smoke test timeout